### PR TITLE
fix(react): Use correct router

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 import Context from './utils/context';
 import { createBrowserHistory } from 'history';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { Router, Switch, Route } from 'react-router-dom';
 
 import ScrollToTop from './components/ScrollToTop';
 


### PR DESCRIPTION
Using the `BrowserRouter` will cause errors because it create it's own
history object and sets that globally. This means it will interfere with
the history created by `createBrowserHistory()`, which is what Sentry
uses to navigate. To fix this, we switch to using the base `Router`,
which doesn't create it's own history, instead relies on the
external history we provide it.