### PR TITLE
TDA Testing

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -31,3 +31,4 @@ node_modules/
 **/node_modules
 
 flask/
+tests/

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ json.dumps(results, default=str)
 `gcloud app deploy` does not support `--update-env-vars RELEASE=$RELEASE` like `gcloud run deploy` does with Cloud Run
 
 
-
 https://dev.to/brad_beggs/handling-react-form-submit-with-redirect-async-await-for-the-beyond-beginner-57of
 
 https://www.pluralsight.com/guides/how-to-transition-to-another-route-on-successful-async-redux-action
@@ -119,4 +118,8 @@ Context
 https://reactjs.org/docs/hooks-effect.html
 
 
-/cart -> /checkout (auto tx) -> checkout (custom tx)
+https://docs.sentry.io/platforms/python/guides/flask/configuration/filtering/#using-sampling-to-filter-transaction-events
+
+Pretty printing in python  
+stuff=sampling_context['wsgi_environ']  
+pp = pprint.PrettyPrinter(indent=4)  

--- a/flask/main.py
+++ b/flask/main.py
@@ -21,12 +21,14 @@ print("> RELEASE", RELEASE)
 print("> ENVIRONMENT", ENVIRONMENT)
 
 def before_send(event, hint):
-    # TODO need this still?
-    if event['request']['method'] == 'OPTIONS':
-        console.log("*** OPTIONS ***")
-        return null
-    # print("> event", event)
     return event
+
+def traces_sampler(sampling_context):
+    REQUEST_METHOD=sampling_context['wsgi_environ']['REQUEST_METHOD']
+    if REQUEST_METHOD == 'OPTIONS':
+        return 0.0
+    else:
+        return 1.0
 
 sentry_sdk.init(
     dsn=DSN,
@@ -34,7 +36,8 @@ sentry_sdk.init(
     environment=ENVIRONMENT,
     integrations=[FlaskIntegration(), SqlalchemyIntegration()],
     traces_sample_rate=1.0,
-    before_send=before_send
+    before_send=before_send,
+    traces_sampler=traces_sampler
 )
 
 app = Flask(__name__)

--- a/flask/main.py
+++ b/flask/main.py
@@ -24,6 +24,7 @@ def before_send(event, hint):
     return event
 
 def traces_sampler(sampling_context):
+    sentry_sdk.set_context("sampling_context", sampling_context)
     REQUEST_METHOD=sampling_context['wsgi_environ']['REQUEST_METHOD']
     if REQUEST_METHOD == 'OPTIONS':
         return 0.0

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -60,6 +60,11 @@ class Checkout extends Component {
     console.log("> response", response)
     console.log("> ok | status | statusText", response.ok, response.status, response.statusText)
 
+    if (!response.ok) {
+      console.log("!response.ok")
+      Sentry.captureException(new Error(response.status + " - " + (response.statusText || "INTERNAL SERVER ERROR")))
+    }
+    
     transaction.finish();
 
     if (!response.ok) {

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -61,8 +61,7 @@ class Checkout extends Component {
     console.log("> ok | status | statusText", response.ok, response.status, response.statusText)
 
     if (!response.ok) {
-      console.log("!response.ok")
-      Sentry.captureException(new Error(response.status + " - " + (response.statusText || "INTERNAL SERVER ERROR")))
+      Sentry.captureException(new Error(response.status + " - " + (response.statusText || "Internal Server Error")))
     }
     
     transaction.finish();

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -38,7 +38,6 @@ class Products extends Component {
           {products.response.map((product) => {
             const itemLink = '/product/' + product.id;
             const averageRating = (product.reviews.reduce((a,b) => a + (b["rating"] || 0),0) / product.reviews.length).toFixed(1)
-            // console.log("averageRating", averageRating)
 
             let stars = [1,2,3,4,5].map((index) => {
               if (index <= averageRating) {

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -38,7 +38,7 @@ class Products extends Component {
           {products.response.map((product) => {
             const itemLink = '/product/' + product.id;
             const averageRating = (product.reviews.reduce((a,b) => a + (b["rating"] || 0),0) / product.reviews.length).toFixed(1)
-            console.log("averageRating", averageRating)
+            // console.log("averageRating", averageRating)
 
             let stars = [1,2,3,4,5].map((index) => {
               if (index <= averageRating) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -76,13 +76,3 @@ How to stop it
 ps fjx
 kill -9 <PID of the script.sh>
 ```
-
-
-## Todo
-Why are OPTIONS http.method transactions surfacing for the AppEngine instance?  
-This doesn't happen when hitting localhost:5000/products
-TRY accessing application-monitoring.com/products manually, see if it happens
-
-
-The average `i` should be 10?  
-for i in range(random.randrange(20))

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,9 +12,11 @@ create_cron_job.sh -> GCP-cron job (runs every 20 min from midnight-6am) -> Trav
 # Tests
 
 ## Setup
-python -m venv env
+```
+python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
+```
 
 ## FrontEnd / Selenium (`frontend_tests` directory)
 Pulls up Sentry frontend in various browsers in parallel via selenium scripts.

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,10 @@ source env/bin/activate
 pip install -r requirements.txt
 ```
 
+Update your endpoint (URL) in `endpoints.yaml`  
+http://application-monitoring-react-dot-sales-engineering-sf.appspot.com/ <-- '/' at end?  
+http://localhost:5000/  
+
 ## FrontEnd / Selenium (`frontend_tests` directory)
 Pulls up Sentry frontend in various browsers in parallel via selenium scripts.
 Test case will add items to cart and then click checkout
@@ -72,3 +76,13 @@ How to stop it
 ps fjx
 kill -9 <PID of the script.sh>
 ```
+
+
+## Todo
+Why are OPTIONS http.method transactions surfacing for the AppEngine instance?  
+This doesn't happen when hitting localhost:5000/products
+TRY accessing application-monitoring.com/products manually, see if it happens
+
+
+The average `i` should be 10?  
+for i in range(random.randrange(20))

--- a/tests/endpoints.yaml
+++ b/tests/endpoints.yaml
@@ -1,4 +1,4 @@
 # endpoints should NOT have "/" at the end
 
 react_endpoints:
- - http://application-monitoring-react-dot-sales-engineering-sf.appspot.com/
+ - http://application-monitoring-react-dot-sales-engineering-sf.appspot.com

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,8 @@
 selenium==3.14.0
 sauceclient>=0.2.1
-pytest==4.4.0
-pytest-xdist
-requests
+pytest==4.6.11
+pytest-xdist==1.34.0
+requests==2.25.1
 pyyaml==3.11
+sentry-sdk==0.19.4
+python-dotenv==0.12.0


### PR DESCRIPTION
## Dry Run | 10 Events (8 Transactions 2 Errors)
Used the mouse, did not run TDA
#### Homepage 1 Transaction
```
/ JS (auto)
```

#### Products 2 Transactions
```
/products JS (auto)
products Python (auto)
```
#### Checkout 5 Transactions 2 Errors
```
/cart JS (auto)
/checkout JS (auto)

checkout JS (custom)
checkout Python (custom)
error JS
error Python

/error JS (auto)
```

## Pytest | -n 1 | range1 | no loop
[40 Events](https://sentry.io/organizations/testorg-az/discover/results/?end=2021-07-06T22%3A12%3A00&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5808655&project=5808623&query=&sort=-timestamp&start=2021-07-06T22%3A07%3A22&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1), 8 Errors, 32 Transactions

```
for i in range(2)
py.test -s -n 1 frontend_tests
```

#### Homepage 4 Transactions
```
/ JS (auto) 4
```
#### Products 8 Transactions
```
/products JS (auto) 4
products Python (auto) 4
```
#### Checkout 35 Events
```
/cart JS (auto) 4
/checkout JS (auto) 4

checkout JS (custom) 8 
checkout Python (custom) 8
error JS 4
error Python 4
/error JS (auto) 3
```
![image](https://user-images.githubusercontent.com/8920574/124672836-999d7700-de6c-11eb-8c96-cb156aa0a993.png)

## Pytest | -n 1 | range10 | no loop | X Events
[400 Events](link.com), (80 Errors, 320 Transactions)
```
for i in range(random.randrange(9))
py.test -s -n 1 frontend_tests
```
![image](https://user-images.githubusercontent.com/8920574/124672352-bb4a2e80-de6b-11eb-9632-619200a07e60.png)


## Pytest | -n 1 | range20 | no loop | 760 Events
[760 Events](https://sentry.io/organizations/testorg-az/discover/results/?end=2021-07-06T21%3A26%3A00&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5808655&project=5808623&query=&sort=-timestamp&start=2021-07-06T20%3A49%3A12&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1), (152 Errors, 608 Transactions)
```
for i in range(random.randrange(19))
py.test -s -n 1 frontend_tests
```
![image](https://user-images.githubusercontent.com/8920574/124668571-ec276500-de65-11eb-92a6-2d8ff2bacd4b.png)


## Fixed
- tests/requirements.txt for installing
- /checkout creates error on frontend when handling 500 response
- No more `OPTIONS` http.method transactions once `traces_sampler` was implemented
- Firefox browser's response objects have a `response.statusText` property which gives lower case "Internal Server Error", and Safari and Chrome's response objects don't have `statusText`, so changing the hard-coded value to lower case "Internal Server Error" so it matches. It's always the same Issue (see below) 

## Conclusion
Speed improves with number of threads until `-n 4`. At `-n 8` the running speed did not improve the speed, despite the macbook having 6 Cores. This is due to exactly 4 browsers at once being run in Selenium.

If `-n 4` w/ `range20` produces 800 events in 518 seconds (8.6minutes)

Then `-n 4` w/ `rand.range20` should average out to range10 and should produce 5581 events in 3600 seconds (1hour)

**Prediction:** Should produce 5,581/hr which is 133,944
**Result:** It produced 3,265/hr which is 78,360/day.

**So expect:** 
78,360/day to 133,944/day
2,350,800/month to 4,018,320/month

## Gotcha
[Safari vs. Chrome and Firefox](https://sentry.io/organizations/testorg-az/discover/results/?end=2021-07-06T22%3A14%3A00&field=title&field=event.type&field=project&field=browser.name&field=timestamp&name=All+Events&project=5808655&project=5808623&query=title%3A%22Error%3A+500%2A%22&sort=-timestamp&start=2021-07-06T22%3A06%3A50&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)
[Safari vs. Chrome and Firefox w/ Issue](https://sentry.io/organizations/testorg-az/discover/results/?end=2021-07-06T22%3A14%3A00.000&field=issue&field=title&field=event.type&field=project&field=browser.name&field=timestamp&name=All+Events&project=5808655&project=5808623&query=title%3A%22Error%3A+500%2A%22&sort=-timestamp&start=2021-07-06T22%3A06%3A50.000&widths=115&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) they're all the same issue, which is good
![image](https://user-images.githubusercontent.com/8920574/124673442-b1c1c600-de6d-11eb-987c-d973042b177d.png)
