### PR TITLE
query params trigger alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,3 @@ https://docs.sentry.io/platforms/python/guides/flask/configuration/filtering/#us
 
 Pretty printing in python  
 stuff=sampling_context['wsgi_environ']  
-pp = pprint.PrettyPrinter(indent=4)  
-
-products: [] // <-- prefer to use this, but get error "products.map is not a function" in Products.js

--- a/README.md
+++ b/README.md
@@ -117,8 +117,4 @@ https://reactjs.org/docs/hooks-state.html
 Context
 https://reactjs.org/docs/hooks-effect.html
 
-
 https://docs.sentry.io/platforms/python/guides/flask/configuration/filtering/#using-sampling-to-filter-transaction-events
-
-Pretty printing in python  
-stuff=sampling_context['wsgi_environ']  

--- a/README.md
+++ b/README.md
@@ -123,3 +123,5 @@ https://docs.sentry.io/platforms/python/guides/flask/configuration/filtering/#us
 Pretty printing in python  
 stuff=sampling_context['wsgi_environ']  
 pp = pprint.PrettyPrinter(indent=4)  
+
+products: [] // <-- prefer to use this, but get error "products.map is not a function" in Products.js

--- a/flask/main.py
+++ b/flask/main.py
@@ -106,8 +106,6 @@ def unhandled_exception():
 
 @app.before_request
 def sentry_event_context():
-    print(" > REQUEST.HEADERS", request.headers)
-    
     se = request.headers.get('se')
     if se not in [None, "undefined"]:
         sentry_sdk.set_tag("se", se)

--- a/flask/main.py
+++ b/flask/main.py
@@ -106,11 +106,16 @@ def unhandled_exception():
     obj['keyDoesntExist']
 
 # TODO - when user arrives at your site, you don't know their email yet. email normally from a session/login, or signup/checkout field.
-# @app.before_request
-# def sentry_event_context():
-#     print('\n> request.headers email', request.headers.get('email'))
-#     with sentry_sdk.configure_scope() as scope:
-#         scope.user = { "email" : request.headers.get('email') }
+@app.before_request
+def sentry_event_context():
+    se = request.headers.get('se')
+    print('\n> request.headers se', se)
+    sentry_sdk.set_tag("se", se)
+    # GLOBAL "configure_scope"
+    # print('\n> request.headers email', request.headers.get('email'))
+    # with sentry_sdk.configure_scope() as scope:
+        # scope.user = { "email" : request.headers.get('email') }
+        # scope.user = { "email" : request.headers.get('email') }
 
 if __name__ == '__main__':
     i = sys.version_info

--- a/flask/main.py
+++ b/flask/main.py
@@ -106,9 +106,19 @@ def unhandled_exception():
 
 @app.before_request
 def sentry_event_context():
+    print(" > REQUEST.HEADERS", request.headers)
+    
     se = request.headers.get('se')
     if se not in [None, "undefined"]:
         sentry_sdk.set_tag("se", se)
+    
+    customerType = request.headers.get('customerType')
+    if customerType not in [None, "undefined"]:
+        sentry_sdk.set_tag("customerType", customerType)
+    
+    email = request.headers.get('email')
+    if email not in [None, "undefined"]:
+        sentry_sdk.set_user({ "email" : email })
 
 if __name__ == '__main__':
     i = sys.version_info

--- a/flask/main.py
+++ b/flask/main.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import sys
-# from flask import abort, jsonify
 from flask import Flask, json, request, make_response
 from flask_cors import CORS
 from dotenv import load_dotenv
@@ -105,17 +104,11 @@ def unhandled_exception():
     obj = {}
     obj['keyDoesntExist']
 
-# TODO - when user arrives at your site, you don't know their email yet. email normally from a session/login, or signup/checkout field.
 @app.before_request
 def sentry_event_context():
     se = request.headers.get('se')
-    print('\n> request.headers se', se)
+    print('\n> se', se)
     sentry_sdk.set_tag("se", se)
-    # GLOBAL "configure_scope"
-    # print('\n> request.headers email', request.headers.get('email'))
-    # with sentry_sdk.configure_scope() as scope:
-        # scope.user = { "email" : request.headers.get('email') }
-        # scope.user = { "email" : request.headers.get('email') }
 
 if __name__ == '__main__':
     i = sys.version_info

--- a/flask/main.py
+++ b/flask/main.py
@@ -105,6 +105,13 @@ def unhandled_exception():
     obj = {}
     obj['keyDoesntExist']
 
+# TODO - when user arrives at your site, you don't know their email yet. email normally from a session/login, or signup/checkout field.
+# @app.before_request
+# def sentry_event_context():
+#     print('\n> request.headers email', request.headers.get('email'))
+#     with sentry_sdk.configure_scope() as scope:
+#         scope.user = { "email" : request.headers.get('email') }
+
 if __name__ == '__main__':
     i = sys.version_info
     if sys.version_info[0] < 3:

--- a/flask/main.py
+++ b/flask/main.py
@@ -107,8 +107,8 @@ def unhandled_exception():
 @app.before_request
 def sentry_event_context():
     se = request.headers.get('se')
-    print('\n> se', se)
-    sentry_sdk.set_tag("se", se)
+    if se not in [None, "undefined"]:
+        sentry_sdk.set_tag("se", se)
 
 if __name__ == '__main__':
     i = sys.version_info

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -47,6 +47,10 @@ class Checkout extends Component {
 
     let response = await fetch(`${BACKEND}/checkout`, {
       method: "POST",
+      headers: {
+        "se": "will"
+        // "email": this.state.email // email here is already in the body
+      },
       body: JSON.stringify({
         cart: cart,
         form: this.state

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -45,17 +45,15 @@ class Checkout extends Component {
     // Do this or the trace won't include the backend transaction
     Sentry.configureScope(scope => scope.setSpan(transaction));
 
-    let se
+    let se, customerType, email
     Sentry.withScope(function(scope) {
-      se = scope._tags.se
-      console.log("scope._tags.se", se)
+      [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
+      email = scope._user.email
     });
 
     let response = await fetch(`${BACKEND}/checkout`, {
       method: "POST",
-      headers: {
-        'se': se
-      },
+      headers: { se, customerType, email },
       body: JSON.stringify({
         cart: cart,
         form: this.state
@@ -65,8 +63,6 @@ class Checkout extends Component {
       console.log("> catches error", err)
       throw Error(err) 
     })
-
-    console.log("> response", response)
     console.log("> ok | status | statusText", response.ok, response.status, response.statusText)
 
     if (!response.ok) {

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -45,7 +45,7 @@ class Checkout extends Component {
     // Do this or the trace won't include the backend transaction
     Sentry.configureScope(scope => scope.setSpan(transaction));
 
-    let se // TODO try configureScope so it persists after the error?
+    let se
     Sentry.withScope(function(scope) {
       se = scope._tags.se
       console.log("scope._tags.se", se)

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -45,10 +45,16 @@ class Checkout extends Component {
     // Do this or the trace won't include the backend transaction
     Sentry.configureScope(scope => scope.setSpan(transaction));
 
+    let se // TODO try configureScope so it persists after the error?
+    Sentry.withScope(function(scope) {
+      se = scope._tags.se
+      console.log("scope._tags.se", se)
+    });
+
     let response = await fetch(`${BACKEND}/checkout`, {
       method: "POST",
       headers: {
-        "se": "will"
+        'se': se
       },
       body: JSON.stringify({
         cart: cart,

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -49,7 +49,6 @@ class Checkout extends Component {
       method: "POST",
       headers: {
         "se": "will"
-        // "email": this.state.email // email here is already in the body
       },
       body: JSON.stringify({
         cart: cart,

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -41,7 +41,6 @@ class Products extends Component {
 
   render() {
     const { cart, products } = this.context;
-
     return products.response.length > 0 ? (
       <div>
         <ul className="products-list">

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -18,17 +18,15 @@ class Products extends Component {
   async componentDidMount(){
     const { products } = this.context;
 
-    let se
+    let se, customerType, email
     Sentry.withScope(function(scope) {
-      se = scope._tags.se
-      console.log("scope._tags.se", se)
+      [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
+      email = scope._user.email
     });
 
     let result = await fetch(`${BACKEND}/products`, {
       method: "GET",
-      headers: {
-        'se': se
-      }
+      headers: { se, customerType, email }
     })
       .then(response => { return response.text() })
       .catch((err) => { throw Error(err) })

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -12,19 +12,18 @@ if (window.location.hostname === "localhost") {
 }
 console.log("BACKEND", BACKEND)
 
-// function useQuery() {
-//   return new URLSearchParams(useLocation().search);
-// }
-
 class Products extends Component {
   static contextType = Context;
 
   async componentDidMount(){
-    // let query = useQuery();
-    let queryParams = this.props.history.location.search
-    console.log("queryParams", queryParams)
+    console.log("this.props", this.props)
 
-    // http://localhost:3000/products?se=will
+    let query = this.props.history.location?.search 
+    query ? 
+      Sentry.configureScope(scope => {
+        scope.setTag("se", query.split("se=").pop())
+      })
+      :console.log("no query string")
 
     const { products } = this.context;
     

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -16,8 +16,6 @@ class Products extends Component {
   static contextType = Context;
 
   async componentDidMount(){
-    console.log("this.props", this.props)
-
     let query = this.props.history.location?.search 
     query ? 
       Sentry.configureScope(scope => {

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -16,17 +16,19 @@ class Products extends Component {
   static contextType = Context;
 
   async componentDidMount(){
-    let query = this.props.history.location?.search 
-    query ? 
-      Sentry.configureScope(scope => {
-        scope.setTag("se", query.split("se=").pop())
-      })
-      :console.log("no query string")
-
     const { products } = this.context;
-    
+
+    let se
+    Sentry.withScope(function(scope) {
+      se = scope._tags.se
+      console.log("scope._tags.se", se)
+    });
+
     let result = await fetch(`${BACKEND}/products`, {
       method: "GET",
+      headers: {
+        'se': se
+      }
     })
       .then(response => { return response.text() })
       .catch((err) => { throw Error(err) })

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -12,10 +12,20 @@ if (window.location.hostname === "localhost") {
 }
 console.log("BACKEND", BACKEND)
 
+// function useQuery() {
+//   return new URLSearchParams(useLocation().search);
+// }
+
 class Products extends Component {
   static contextType = Context;
 
   async componentDidMount(){
+    // let query = useQuery();
+    let queryParams = this.props.history.location.search
+    console.log("queryParams", queryParams)
+
+    // http://localhost:3000/products?se=will
+
     const { products } = this.context;
     
     let result = await fetch(`${BACKEND}/products`, {
@@ -32,6 +42,7 @@ class Products extends Component {
 
   render() {
     const { cart, products } = this.context;
+
     return products.response.length > 0 ? (
       <div>
         <ul className="products-list">

--- a/src/components/ProductsJoin.js
+++ b/src/components/ProductsJoin.js
@@ -17,17 +17,15 @@ class Products extends Component {
   async componentDidMount(){
     const { products } = this.context;
 
-    let se
+    let se, customerType, email
     Sentry.withScope(function(scope) {
-      se = scope._tags.se
-      console.log("scope._tags.se", se)
+      [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
+      email = scope._user.email
     });
     
     let result = await fetch(`${BACKEND}/products-join`, {
       method: "GET",
-      headers: {
-        'se': se
-      }
+      headers: { se, customerType, email }
     })
       .then(response => { return response.text() })
       .catch((err) => { throw Error(err) })

--- a/src/components/ProductsJoin.js
+++ b/src/components/ProductsJoin.js
@@ -15,6 +15,13 @@ class Products extends Component {
   static contextType = Context;
 
   async componentDidMount(){
+    let query = this.props.history.location?.search 
+    query ? 
+      Sentry.configureScope(scope => {
+        scope.setTag("se", query.split("se=").pop())
+      })
+      :console.log("no query string")
+      
     const { products } = this.context;
     
     let result = await fetch(`${BACKEND}/products-join`, {

--- a/src/components/ProductsJoin.js
+++ b/src/components/ProductsJoin.js
@@ -15,17 +15,19 @@ class Products extends Component {
   static contextType = Context;
 
   async componentDidMount(){
-    let query = this.props.history.location?.search 
-    query ? 
-      Sentry.configureScope(scope => {
-        scope.setTag("se", query.split("se=").pop())
-      })
-      :console.log("no query string")
-      
     const { products } = this.context;
+
+    let se
+    Sentry.withScope(function(scope) {
+      se = scope._tags.se
+      console.log("scope._tags.se", se)
+    });
     
     let result = await fetch(`${BACKEND}/products-join`, {
       method: "GET",
+      headers: {
+        'se': se
+      }
     })
       .then(response => { return response.text() })
       .catch((err) => { throw Error(err) })

--- a/src/index.js
+++ b/src/index.js
@@ -79,18 +79,16 @@ class App extends Component {
     Sentry.configureScope(scope => {
       
       const customerType = ["medium-plan", "large-plan", "small-plan", "enterprise"][Math.floor(Math.random() * 4)]
-      console.log("index CUSTEROMTYPE", customerType)
       scope.setTag("customerType", customerType )
       
       let queryParam = history.location.search
       if (queryParam.includes("se=")) {
         const se = queryParam.split("se=").pop()
-        console.log("index SE", se)
+        console.log("se", se)
         scope.setTag("se", se)
       }
 
       let email = Math.random().toString(36).substring(2, 6) + "@yahoo.com";
-      console.log("index EMAIL", email)
       scope.setUser({ email: email })
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const SentryRoute = Sentry.withSentryRouting(Route);
 
 let ENVIRONMENT
 console.log("window.location", window.location)
-if (window.location.hostname === "localhost") { // npm start, npm run build (run.sh)
+if (window.location.hostname === "localhost") {
   ENVIRONMENT = "test"
 } else { // App Engine
   ENVIRONMENT = "production"

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import { Integrations } from '@sentry/tracing';
 import Context from './utils/context';
 import { createBrowserHistory } from 'history';
 import { Router, Switch, Route } from 'react-router-dom';
-// import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import ScrollToTop from './components/ScrollToTop';
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { Integrations } from '@sentry/tracing';
 import Context from './utils/context';
 import { createBrowserHistory } from 'history';
 import { Router, Switch, Route } from 'react-router-dom';
+// import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import ScrollToTop from './components/ScrollToTop';
 
@@ -167,8 +168,7 @@ class App extends Component {
                   path="/product/:id"
                   component={Product}
                 ></SentryRoute>
-                <Route path="/products">
-                  <Products />
+                <Route path="/products" component={Products}>
                 </Route>
                 <Route path="/products-join">
                   <ProductsJoin />

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,9 @@ import { createBrowserHistory } from 'history';
 import { Router, Switch, Route } from 'react-router-dom';
 
 import ScrollToTop from './components/ScrollToTop';
-
 import Button from './components/ButtonLink';
 import Footer from './components/Footer';
 import Nav from './components/Nav';
-
 import About from './components/About';
 import Cart from './components/Cart';
 import Checkout from './components/Checkout';
@@ -24,10 +22,6 @@ import NotFound from './components/NotFound';
 import Product from './components/Product';
 import Products from './components/Products';
 import ProductsJoin from './components/ProductsJoin';
-// import productOne from './components/products/1';
-// import productTwo from './components/products/2';
-// import productThree from './components/products/3';
-// import productFour from './components/products/4';
 
 import plantsBackground from './assets/plants-background-img.jpg';
 
@@ -38,9 +32,9 @@ const SentryRoute = Sentry.withSentryRouting(Route);
 
 let ENVIRONMENT
 console.log("window.location", window.location)
-if (window.location.hostname === "localhost") {
+if (window.location.hostname === "localhost") { // npm start, npm run build (run.sh)
   ENVIRONMENT = "test"
-} else {
+} else { // App Engine
   ENVIRONMENT = "production"
 }
 const DSN = process.env.REACT_APP_DSN
@@ -60,13 +54,12 @@ Sentry.init({
   release: RELEASE,
   environment: ENVIRONMENT,
   beforeSend(event) {
-    // console.log("event",event)
     return event;
   }
-  // debug:true
 });
 
 class App extends Component {
+  
   constructor() {
     super();
     this.state = {
@@ -78,11 +71,17 @@ class App extends Component {
       products: {
         response: []
       }
-      // products: [] // <-- prefer to use this, but get error "products.map is not a function" in Products.js
     };
 
     this.cartReducer = this.cartReducer.bind(this);
     this.productsReducer = this.productsReducer.bind(this);
+
+    let queryParam = history.location.search
+    if (queryParam) {
+      Sentry.configureScope(scope => {
+        scope.setTag("se", queryParam.split("se=").pop())
+      })
+    }
   }
 
   productsReducer({ action, response }) {

--- a/src/index.js
+++ b/src/index.js
@@ -75,13 +75,24 @@ class App extends Component {
 
     this.cartReducer = this.cartReducer.bind(this);
     this.productsReducer = this.productsReducer.bind(this);
+    // These also get passed via request headers
+    Sentry.configureScope(scope => {
+      
+      const customerType = ["medium-plan", "large-plan", "small-plan", "enterprise"][Math.floor(Math.random() * 4)]
+      console.log("index CUSTEROMTYPE", customerType)
+      scope.setTag("customerType", customerType )
+      
+      let queryParam = history.location.search
+      if (queryParam.includes("se=")) {
+        const se = queryParam.split("se=").pop()
+        console.log("index SE", se)
+        scope.setTag("se", se)
+      }
 
-    let queryParam = history.location.search
-    if (queryParam) {
-      Sentry.configureScope(scope => {
-        scope.setTag("se", queryParam.split("se=").pop())
-      })
-    }
+      let email = Math.random().toString(36).substring(2, 6) + "@yahoo.com";
+      console.log("index EMAIL", email)
+      scope.setUser({ email: email })
+    })
   }
 
   productsReducer({ action, response }) {

--- a/src/index.js
+++ b/src/index.js
@@ -159,19 +159,10 @@ class App extends Component {
                 <Route path="/complete" component={Complete} />
                 <Route path="/error" component={CompleteError} />
                 <Route path="/cra" component={Cra} />
-                <SentryRoute
-                  path="/employee/:slug"
-                  component={Employee}
-                ></SentryRoute>
-                <SentryRoute
-                  path="/product/:id"
-                  component={Product}
-                ></SentryRoute>
-                <Route path="/products" component={Products}>
-                </Route>
-                <Route path="/products-join">
-                  <ProductsJoin />
-                </Route>
+                <SentryRoute path="/employee/:slug" component={Employee}></SentryRoute>
+                <SentryRoute path="/product/:id" component={Product}></SentryRoute>
+                <Route path="/products" component={Products} />
+                <Route path="/products-join" component={ProductsJoin} />
                 <Route component={NotFound} />
               </Switch>
             </div>


### PR DESCRIPTION
## Overview
- Set `se=<name>` tag on /products pageload so that it's retained for when the error gets made later.
- Verify it stays on scope across navigation state changes.

NOTE - email gets set in src/index.js and overrides the email in the checkout form (which gets passed in the request body). Email normally provided by session login or signup/checkout, and not right when a visitor lands on the home page.

NOTE - Getting the 'se' tag off of the sentry scope and having to set for every request's headers... could implement a new requests client so can hook into the request to set this (DRY).

NOTE - checking for 'se' tag in python as None or "undefined" because it's sometimes sent as "undefined" from frontend. We implement the change here in the before_request, or else have to instrument logic for every frontend request's 'header' parameter.

## Steps
1. visit the products page with your name as a query param for `se` http://localhost:5000?se=will
2. This gets parsed in componentDidMount "?se=will" and set as a tag called 'se'.
3. the tag's value persists through healthy and unsuccessful checkouts.
4. it triggers the Alert.

Must have Alert set like:
![image](https://user-images.githubusercontent.com/8920574/125371701-2eedaf00-e336-11eb-8521-2cc6858613c0.png)

## Testing
The transactions are...

[/products](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:007d3d98dd374a17801b9d00377f24f0/?field=title&field=event.type&field=project&field=se&field=timestamp&name=All+Events&project=5808623&query=&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) has se tag.

all the way through...

[/error](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:f99f704208b243518e82ca7f3398d4cc/?field=title&field=event.type&field=project&field=se&field=timestamp&name=All+Events&project=5808623&query=&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) transaction and the [error](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:164a99dd65604f67b193e87b48b8e795/?field=title&field=event.type&field=project&field=se&field=timestamp&name=All+Events&project=5808623&query=&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) both have se tag.

And the SE tag in the alert looked like:
![image](https://user-images.githubusercontent.com/8920574/125372011-ec78a200-e336-11eb-9d6b-d2427bb20bf2.png)
^ you could remove this tag from your alert configuration.

The Alert did not come through when I left out the `?se=will` query param, which is the expected behavior.

Also...
If you don't put a `se=<name>` query param, then the `se` tag will not get set:
![image](https://user-images.githubusercontent.com/8920574/125371297-4d06df80-e335-11eb-8fa8-d78520a6808d.png)

## Didn't Work
Clicking 'Browse Products' doesn't set it for you. You have to remember to set it manually when you're on the /products page. You could optionally pass one via a .env file property, and set it if it's present, but that may be too much work AND that's only useful if you're running it locally. On the admin instance - there'd be know way what to auto set that as, and so it's better to write it manually in the URL bar.

https://softchris.github.io/books/react/router-parameters/ did not work because "react React Hook "useQuery" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function"

Because this was per route, and we solutioned something different in src/index.js to apply everywhere.
```
    let query = this.props.history.location?.search 
    query ? 
      Sentry.configureScope(scope => {
        scope.setTag("se", query.split("se=").pop())
      })
      :console.log("no query string")
```