### PR TITLE
Error Handling Fetches

### DIFF
--- a/flask/app.yaml
+++ b/flask/app.yaml
@@ -1,2 +1,2 @@
-service: -<NAME>-
+service: staging-application-monitoring-flask
 runtime: python38

--- a/flask/db.py
+++ b/flask/db.py
@@ -35,7 +35,8 @@ else:
 
 # N+1 because a sql query for every product n
 def get_products():
-    raise Exception("forced exception")
+    # return "forced exception 2", 500
+    # raise Exception("forced exception")
     results = []
     try:
         with sentry_sdk.start_span(op="get_products", description="db.connect"):

--- a/flask/db.py
+++ b/flask/db.py
@@ -35,6 +35,7 @@ else:
 
 # N+1 because a sql query for every product n
 def get_products():
+    raise Exception("forced exception")
     results = []
     try:
         with sentry_sdk.start_span(op="get_products", description="db.connect"):
@@ -132,7 +133,7 @@ def get_inventory(cart):
 
     except Exception as exception:
         print(exception)
-        Sentry.capture_exception(exception)
+        sentry_sdk.capture_exception(exception)
 
     return inventory
 

--- a/flask/db.py
+++ b/flask/db.py
@@ -35,8 +35,6 @@ else:
 
 # N+1 because a sql query for every product n
 def get_products():
-    # return "forced exception 2", 500
-    # raise Exception("forced exception")
     results = []
     try:
         with sentry_sdk.start_span(op="get_products", description="db.connect"):

--- a/react/app.yaml
+++ b/react/app.yaml
@@ -1,6 +1,6 @@
   
 env: standard
-service: -<NAME>-
+service: staging-application-monitoring-react
 runtime: nodejs14
 
 handlers:

--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -37,6 +37,26 @@ class Checkout extends Component {
     });
   }
 
+  async checkout(cart) {
+    let se, customerType, email
+    Sentry.withScope(function(scope) {
+      [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
+      email = scope._user.email
+    });
+
+    return await fetch(`${BACKEND}/checkout`, {
+      method: "POST",
+      headers: { se, customerType, email, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        cart: cart,
+        form: this.state
+      })
+    })
+    .catch((err) => { 
+      return { ok: false, status: 500 }
+    })
+  }
+
   async handleSubmit(event) {
     event.preventDefault();
 
@@ -48,36 +68,19 @@ class Checkout extends Component {
     // Do this or the trace won't include the backend transaction
     Sentry.configureScope(scope => scope.setSpan(transaction));
 
-    let se, customerType, email
-    Sentry.withScope(function(scope) {
-      [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
-      email = scope._user.email
-    });
-
-    this.setState({...this.state,loading: true});
     window.scrollTo({
       top: 0, 
       behavior: 'auto'
     });
 
-    let response = await fetch(`${BACKEND}/checkout`, {
-      method: "POST",
-      headers: { se, customerType, email, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        cart: cart,
-        form: this.state
-      })
-    })
-    .catch((err) => { 
-      return { ok: false, status: 500 }
-    })
+    this.setState({...this.state,loading: true});
 
+    let response = await this.checkout(cart)
     if (!response.ok) {
       Sentry.captureException(new Error(response.status + " - " + (response.statusText || "Internal Server Error")))
     }
 
     this.setState({...this.state,loading: false});
-    
     transaction.finish();
 
     if (!response.ok) {

--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -73,7 +73,9 @@ class Checkout extends Component {
       // Firefox will error into this block
       console.log("> catches error", err)
     })
-    console.log("> ok | status | statusText", response.ok, response.status, response.statusText)
+
+    // TODO 's is undefined'
+    // console.log("> ok | status | statusText", response.ok, response.status, response.statusText)
 
     if (!response.ok) {
       Sentry.captureException(new Error(response.status + " - " + (response.statusText || "Internal Server Error")))

--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -1,11 +1,10 @@
 import { Component } from 'react';
-import { createBrowserHistory } from 'history';
 import Context from '../utils/context';
 import { Link } from 'react-router-dom';
 import './checkout.css';
 import * as Sentry from '@sentry/react';
 import { connect } from 'react-redux'
-import { setProducts, addProduct, removeProduct } from '../actions'
+import { setProducts, addProduct } from '../actions'
 import Loader from "react-loader-spinner";
 
 var BACKEND = ""
@@ -70,12 +69,8 @@ class Checkout extends Component {
       })
     })
     .catch((err) => { 
-      // Firefox will error into this block
-      console.log("> catches error", err)
+      return { ok: false, status: 500 }
     })
-
-    // TODO 's is undefined'
-    // console.log("> ok | status | statusText", response.ok, response.status, response.statusText)
 
     if (!response.ok) {
       Sentry.captureException(new Error(response.status + " - " + (response.statusText || "Internal Server Error")))

--- a/react/src/components/Complete.js
+++ b/react/src/components/Complete.js
@@ -1,4 +1,3 @@
-import Context from '../utils/context';
 import { Link } from 'react-router-dom';
 import './complete.css';
 import { useSelector } from 'react-redux'

--- a/react/src/components/CompleteError.js
+++ b/react/src/components/CompleteError.js
@@ -4,8 +4,8 @@ import './complete.css';
 
 class CompleteError extends Component {
   render() {
-    let errorInfo = this.props.history.location.state
-    console.log("> errorInfo", errorInfo)
+    // let errorInfo = this.props.history.location.state
+    // console.log("> errorInfo", errorInfo)
 
     return (
       <div className="checkout-container-complete">

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -30,7 +30,11 @@ class Products extends Component {
       headers: { se, customerType, email }
     })
       .then(response => { return response.text() })
-      .catch((err) => { throw Error(err) })
+      .catch((err) => { 
+        // TODO Sentry.captureException w/ 'error loading products'. withScope OR beforeSend, update title, pass same exception object?
+        // diff error depending on browser
+        throw Error(err) 
+      })
 
     console.log('> Products from backend', JSON.parse(result))
     // Sentry.captureException(new Error("this is an exception"))

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -13,27 +13,49 @@ if (window.location.hostname === "localhost") {
 } else {
   BACKEND = process.env.REACT_APP_BACKEND
 }
+console.log("BACKEND", BACKEND)
 
 class ProductsJoin extends Component {
   static contextType = Context;
 
-  async componentDidMount(){
+  // getProductsJoin handles error responses differently, depending on the browser used
+  async getProductsJoin() {
     let se, customerType, email
     Sentry.withScope(function(scope) {
       [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
       email = scope._user.email
     });
-    
+
     let result = await fetch(`${BACKEND}/products-join`, {
       method: "GET",
-      headers: { se, customerType, email }
+      headers: { se, customerType, email, "Content-Type": "application/json" }
     })
-      .then(response => { return response.text() })
-      .catch((err) => { throw Error(err) })
+      .catch((err) => { 
+        return { ok: false, status: 500}
+      })
 
-    // console.log('> Products from backend', JSON.parse(result))
-    this.props.setProducts(JSON.parse(result))
-    return result
+    if (!result.ok) {
+      Sentry.configureScope(function(scope) {
+        Sentry.setContext("err", {
+          status: result.status,
+          statusText: result.statusText
+        })
+      });
+      return Promise.reject();
+    } else {
+      const jsonValue = await result.json()
+      return Promise.resolve(jsonValue)
+    }
+  }
+
+  async componentDidMount(){
+    var products
+    try {
+      products = await this.getProductsJoin();
+      this.props.setProducts(products)
+    } catch(err) {
+      Sentry.captureException(new Error("app unable to load products"));
+    }
   }
 
   render() {

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -31,8 +31,7 @@ class ProductsJoin extends Component {
       .then(response => { return response.text() })
       .catch((err) => { throw Error(err) })
 
-    console.log('> Products from backend', JSON.parse(result))
-    // Sentry.captureException(new Error("this is an exception"))
+    // console.log('> Products from backend', JSON.parse(result))
     this.props.setProducts(JSON.parse(result))
     return result
   }

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -60,10 +60,10 @@ Sentry.init({
   release: RELEASE,
   environment: ENVIRONMENT,
   beforeSend(event, hint) {
-    // Issue Grouping - for UnhandledExceptions
+    // event.exception, filename, tags, breadcrumbs
     const exception = hint.originalException
     if (exception instanceof UnhandledException) {
-      event.fingerprint = ['{{ default }}', process.env.REACT_APP_RELEASE ];
+      event.fingerprint = ['unhandled-exception', process.env.REACT_APP_RELEASE ];
     }
     return event;
   }

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -60,7 +60,6 @@ Sentry.init({
   release: RELEASE,
   environment: ENVIRONMENT,
   beforeSend(event, hint) {
-    // event.exception, filename, tags, breadcrumbs
     const exception = hint.originalException
     if (exception instanceof UnhandledException) {
       event.fingerprint = ['unhandled-exception', process.env.REACT_APP_RELEASE ];

--- a/react/src/utils/errors.js
+++ b/react/src/utils/errors.js
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { createBrowserHistory } from 'history';
 const history = createBrowserHistory();
 

--- a/tests/frontend_tests/test_add_to_cart.py
+++ b/tests/frontend_tests/test_add_to_cart.py
@@ -27,6 +27,7 @@ def test_add_to_cart(driver):
                 # Wait for button to be loaded in (no randomizing the sleep, because randomizing the sleep statement does not affect any transaction or span durations. there's no observable benefit)
                 time.sleep(5)
 
+                # https://stackoverflow.com/questions/2244270/get-a-try-statement-to-loop-around-until-correct-value-obtained/2244307
                 add_to_cart_btn = driver.find_element_by_css_selector('.products-list button')
                 for i in range(random.randrange(4) + 1):
                     add_to_cart_btn.click()


### PR DESCRIPTION
## Todo
Update the ProductsJoin
- `/list` route
- `/about`
- `/employee/:id`
- try statement loop until /products are loaded

# Done
- `try/catch` for /products
- fixed fingerprint homepage error (Release Health), since it was having a different stacktrace per browser.
- updated error handling for /checkout should bring more consistent errors via TestDataAutomation.

Firefox and Chrome both error'd into same code block:
![image](https://user-images.githubusercontent.com/8920574/128766200-63538d6d-232c-4111-bace-f3a6546c996e.png)
