### PR TITLE
Throw random error on forced crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ Also called the Empower Plant UI/UX. This project was bootstrapped with [Create 
 Permit your IP address in CloudSQL.
 
 **Test**
-1. Create a .env and enter your DSN. See .env.example for an example.
-2. Create a flask/.env and enter your DSN. See .env.example for an example. Fill out all fields so data can be read from the database.
+1. Create a `react/.env` and enter your DSN. See .env.example for an example.
+2. Create a `flask/.env` and enter your DSN. See .env.example for an example. Fill out all fields so data can be read from the database.
 
 **Production** - AppEngine
 1. Enter a value for REACT_APP_BACKEND in .env, as this represents the Flask AppEngine.
 
 ```
 # React
+cd react
 npm install
 
 # Flask
@@ -41,14 +42,23 @@ cd flask
 
 **Test**
 ```
-# React w/ sourcemaps, suspect commits
+# Pick one of two ways to run the React app:
+
+# 1) Run React app w/ sourcemaps, suspect commits
+# Recommended to use this command rather than `npm start`, as
+# run.sh uploads source maps and handles crashes more
+# realistically.
 ./run.sh
 
-# React w/ hot reload
+# 2) Run React app w/ hot reload
+# NOTE: this will cause crashing errors to be tagged
+#   in sentry as handled (`handled: true`)
 npm start
 
+```
 
-# Flask
+```
+# Run the Flask app
 ./run.sh
 ```
 

--- a/react/src/utils/errors.js
+++ b/react/src/utils/errors.js
@@ -1,22 +1,49 @@
 import { createBrowserHistory } from 'history';
 const history = createBrowserHistory();
 
+// ERRORS
+const notAFunctionError = () => {
+  const someArray = [{ func: function () {}}];
+  someArray[1].func();
+}
+const uriError = () => decodeURIComponent('%');
+const syntaxError = () => eval('foo bar');
+const rangeError = () => {
+  throw new RangeError('Parameter must be between 1 and 100');
+}
+const unhandledError = () => {
+  throw new UnhandledException('unhandled error')
+}
+
+const randomErrors = [
+  notAFunctionError,
+  uriError,
+  syntaxError,
+  rangeError,
+  unhandledError
+]
+
+const throwRandomError = () => {
+  const randomNum = parseInt(Math.random()*randomErrors.length)
+  randomErrors[randomNum]()
+}
+
 var probability = function(n) {
   return !!n && Math.random() <= n;
 };
 
 const crasher = () => {
-  let queryParams = new URLSearchParams(history.location.search)
+  const queryParams = new URLSearchParams(history.location.search)
   if (queryParams !== "") {
-      let crash = queryParams.get("crash")
-      if (crash) {
-            console.log("> crash", crash)
-            if (crash === "true" || probability(parseFloat(crash))) {
-              throw new UnhandledException('unhandled error')
-            }
+    const crash = queryParams.get("crash")
+    if (crash) {
+      console.log("> crash", crash)
+      if (crash === "true" || probability(parseFloat(crash))) {
+        throwRandomError();
       }
+    }
   } else {
-      console.log("> queryParam was", queryParams)
+    console.log("> queryParam was", queryParams)
   }
 }
 

--- a/react/src/utils/errors.js
+++ b/react/src/utils/errors.js
@@ -6,7 +6,9 @@ const notAFunctionError = () => {
   const someArray = [{ func: function () {}}];
   someArray[1].func();
 }
-const uriError = () => decodeURIComponent('%');
+const referenceError = () => {
+  throw new ReferenceError('undefinedVariable is not defined')
+};
 const syntaxError = () => eval('foo bar');
 const rangeError = () => {
   throw new RangeError('Parameter must be between 1 and 100');
@@ -17,7 +19,7 @@ const unhandledError = () => {
 
 const randomErrors = [
   notAFunctionError,
-  uriError,
+  referenceError,
   syntaxError,
   rangeError,
   unhandledError


### PR DESCRIPTION
**Background**
Functionality already exists to force a crash to the demo application by passing the query param `crash=true`. Previously this would result in only one type of error, `UnhandledException`. Given there was only one error type, only one Issue in Sentry was created and it was therefore less realistic for demo purposes than being able to show a customer multiple errors.

**Updates in this PR**
- This PR adds a handful of other error types and chooses a random one to throw, when a crash is forced.
- The option to crash based on probability (i.e. 20% of the time with `crash=0.2`) should remain unchanged.
- See screenshot of sentry.io showing different Issue entries for each error type. Note that a `beforeSend` hook currently forces all `UnhandledException`s to be set to the same fingerprint of `'unhandled-exception'`. This PR doesn't touch that logic because I'm not sure if/how we'll want the fingerprinting logic to change. Without any changes to the current fingerprinting logic, each of these errors should be grouped according to stack trace, as seen in the screenshot below.

## Link to Issues
- 💡 now showing `handled: false`, and with source maps uploaded.
- [Unhandled error that existed previously](https://sentry.io/organizations/testorg-az/issues/2614163848/?project=5938093&query=is%3Aunresolved)
- [RangeError](https://sentry.io/organizations/testorg-az/issues/2616426553/?project=5938093&query=is%3Aunresolved)
- [SyntaxError](https://sentry.io/organizations/testorg-az/issues/2616426437/?project=5938093&query=is%3Aunresolved)
- [URIError](https://sentry.io/organizations/testorg-az/issues/2616435052/?project=5938093&query=is%3Aunresolved)
- [TypeError](https://sentry.io/organizations/testorg-az/issues/2616435066/?project=5938093&query=is%3Aunresolved)

## Screenshots

<img width="1792" alt="Screen Shot 2021-08-30 at 4 30 59 PM" src="https://user-images.githubusercontent.com/12092849/131418718-7325b658-4f29-48b5-aa0f-03ba38f85f2b.png">

![Screen Shot 2021-08-30 at 4 30 17 PM](https://user-images.githubusercontent.com/12092849/131418748-764bf400-1f55-4112-b4d8-b4b383a0313f.png)

![Screen Shot 2021-08-30 at 4 30 25 PM](https://user-images.githubusercontent.com/12092849/131418750-93be278d-03a9-43c6-b514-13c6432ff24f.png)

