### PR TITLE
Route requests to different backend URLs based on backend-type query parameter

### DIFF
--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -7,13 +7,6 @@ import { connect } from 'react-redux'
 import { setProducts, addProduct } from '../actions'
 import Loader from "react-loader-spinner";
 
-var BACKEND = ""
-if (window.location.hostname === "localhost") {
-  BACKEND = "http://localhost:8080"
-} else {
-  BACKEND = process.env.REACT_APP_BACKEND
-}
-
 class Checkout extends Component {
   static contextType = Context;
 
@@ -44,7 +37,8 @@ class Checkout extends Component {
       email = scope._user.email
     });
 
-    return await fetch(`${BACKEND}/checkout`, {
+    console.log("checking out =>>>>>>>>> " + this.props.backend)
+    return await fetch(this.props.backend + "/checkout", {
       method: "POST",
       headers: { se, customerType, email, "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -7,14 +7,6 @@ import { connect } from 'react-redux'
 import { setProducts, addProduct } from '../actions'
 import Loader from "react-loader-spinner";
 
-var BACKEND = ""
-if (window.location.hostname === "localhost") {
-  BACKEND = "http://localhost:8080"
-} else {
-  BACKEND = process.env.REACT_APP_BACKEND
-}
-console.log("BACKEND", BACKEND)
-
 class Products extends Component {
   static contextType = Context;
 
@@ -26,7 +18,8 @@ class Products extends Component {
       email = scope._user.email
     });
 
-    let result = await fetch(`${BACKEND}/products`, {
+    console.log("fetching products from backend =>>>>>>>>> " + this.props.backend)
+    let result = await fetch(this.props.backend + "/products", {
       method: "GET",
       headers: { se, customerType, email, "Content-Type": "application/json" }
     })
@@ -54,7 +47,7 @@ class Products extends Component {
       products = await this.getProducts();
       this.props.setProducts(products)
     } catch(err) {
-      Sentry.captureException(new Error("app unable to load products"));
+      Sentry.captureException(new Error("app unable to load products: " + err));
     }
   }
 

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -7,14 +7,6 @@ import { connect } from 'react-redux'
 import { setProducts, addProduct } from '../actions'
 import Loader from "react-loader-spinner";
 
-var BACKEND = ""
-if (window.location.hostname === "localhost") {
-  BACKEND = "http://localhost:8080"
-} else {
-  BACKEND = process.env.REACT_APP_BACKEND
-}
-console.log("BACKEND", BACKEND)
-
 class ProductsJoin extends Component {
   static contextType = Context;
 
@@ -26,7 +18,8 @@ class ProductsJoin extends Component {
       email = scope._user.email
     });
 
-    let result = await fetch(`${BACKEND}/products-join`, {
+    console.log("fetching joined products from backend =>>>>>>>>> " + this.props.backend)
+    let result = await fetch(this.props.backend + "/products-join", {
       method: "GET",
       headers: { se, customerType, email, "Content-Type": "application/json" }
     })

--- a/react/src/utils/backendrouter.js
+++ b/react/src/utils/backendrouter.js
@@ -1,0 +1,38 @@
+const DEFAULT_BACKEND = "flask"
+const SUPPORTED_BACKEND_TYPES = {
+  "flask": {
+      "test": "http://localhost:8080",
+      "prod": process.env.FLASK_BACKEND || process.env.REACT_APP_BACKEND
+  },
+  "express": {
+      "test": "http://localhost:**TBD**",
+      "prod": process.env.EXPRESS_BACKEND
+  },
+  "springboot": {
+      "test": "http://localhost:**TBD**",
+      "prod": process.env.SPRINGBOOT_BACKEND
+  }
+}
+
+const determineBackendType = (desiredBackend) => {
+    if (desiredBackend) {
+        if (SUPPORTED_BACKEND_TYPES[desiredBackend]) {
+          return desiredBackend
+        } else {
+          const warnText = "You tried to set backend type as '" + desiredBackend + "', which is not supported. Proceeding with the default type: '" + DEFAULT_BACKEND + "'"
+          alert(warnText)
+          console.log(warnText)
+        }
+    }
+    return DEFAULT_BACKEND
+}
+
+const determineBackendUrl = (backendType, environment) => {
+    const urlOptions = SUPPORTED_BACKEND_TYPES[backendType]
+    if (environment === "test") {
+        return urlOptions["test"]
+    }
+    return urlOptions["prod"]
+}
+
+export { determineBackendType, determineBackendUrl }

--- a/react/src/utils/backendrouter.js
+++ b/react/src/utils/backendrouter.js
@@ -2,15 +2,15 @@ const DEFAULT_BACKEND = "flask"
 const SUPPORTED_BACKEND_TYPES = {
   "flask": {
       "test": "http://localhost:8080",
-      "prod": process.env.FLASK_BACKEND || process.env.REACT_APP_BACKEND
+      "production": process.env.FLASK_BACKEND || process.env.REACT_APP_BACKEND
   },
   "express": {
       "test": "http://localhost:**TBD**",
-      "prod": process.env.EXPRESS_BACKEND
+      "production": process.env.EXPRESS_BACKEND
   },
   "springboot": {
       "test": "http://localhost:**TBD**",
-      "prod": process.env.SPRINGBOOT_BACKEND
+      "production": process.env.SPRINGBOOT_BACKEND
   }
 }
 
@@ -28,11 +28,7 @@ const determineBackendType = (desiredBackend) => {
 }
 
 const determineBackendUrl = (backendType, environment) => {
-    const urlOptions = SUPPORTED_BACKEND_TYPES[backendType]
-    if (environment === "test") {
-        return urlOptions["test"]
-    }
-    return urlOptions["prod"]
+    return SUPPORTED_BACKEND_TYPES[backendType][environment]
 }
 
 export { determineBackendType, determineBackendUrl }


### PR DESCRIPTION
### Task Overview
- Permit hitting different backend URLs based on a passed query parameter, i.e. `?backend=express`. 
- This will be used soon by me and Simon for our Springboot/Express onboarding tasks
- This is very easily extensible to any other type of backend we might want empower plant to support

### Acceptance Criteria
✅ Should show up in `tags` in sentry.io
✅ Should hit different URLs depending on environment and specified backend type
✅ Should default to flask if no backend specified
✅ If an invalid backend type is specified, i.e. `?backend=invalid_type`, `alert` the user and proceed with using the flask backend.
✅ This should work whether accessing the homepage first and clicking through to products page, or, accessing the products page directly.

### Screenshots
You can see that the `backendType` was reported to Sentry as a tag.

<img width="1217" alt="Screen Shot 2021-09-13 at 11 04 42 AM" src="https://user-images.githubusercontent.com/12092849/133145496-8aeb57a6-8af5-46cd-93c9-1dc73e7bf74d.png">
