### PR TITLE
Python Fingerprinting

### DIFF
--- a/flask/main.py
+++ b/flask/main.py
@@ -21,6 +21,11 @@ print("> RELEASE", RELEASE)
 print("> ENVIRONMENT", ENVIRONMENT)
 
 def before_send(event, hint):
+    # 2. parse 'se' from tags <-- should be available because already getting from @app.before_request
+    # 3. if se 'tda' then one fingerprint ELSE
+    # 4. if se       then other fingerprint
+    
+    # TODO could check from request headers, or from a queryParam?
     return event
 
 def traces_sampler(sampling_context):

--- a/flask/main.py
+++ b/flask/main.py
@@ -20,19 +20,16 @@ print("> DSN", DSN)
 print("> RELEASE", RELEASE)
 print("> ENVIRONMENT", ENVIRONMENT)
 
-# TODO could check from request headers, or from a queryParam?
 def before_send(event, hint):
     
+    # 'se' tag was set in app.before_request
     se = None
     with sentry_sdk.configure_scope() as scope:
-        print("> scope._tags", scope._tags)
         se = scope._tags['se']
     
     if se == "tda":
-        print("\ntda")
-        event['fingerprint'] = [ '{{ default }}', se, RELEASE ]    
-    if se not in [None, "undefined"]:
-        print("\nse", se")
+        event['fingerprint'] = [ '{{ default }}', se, RELEASE ]
+    elif se not in [None, "undefined"]:
         event['fingerprint'] = [ '{{ default }}', se]    
 
     return event

--- a/flask/main.py
+++ b/flask/main.py
@@ -20,12 +20,21 @@ print("> DSN", DSN)
 print("> RELEASE", RELEASE)
 print("> ENVIRONMENT", ENVIRONMENT)
 
+# TODO could check from request headers, or from a queryParam?
 def before_send(event, hint):
-    # 2. parse 'se' from tags <-- should be available because already getting from @app.before_request
-    # 3. if se 'tda' then one fingerprint ELSE
-    # 4. if se       then other fingerprint
     
-    # TODO could check from request headers, or from a queryParam?
+    se = None
+    with sentry_sdk.configure_scope() as scope:
+        print("> scope._tags", scope._tags)
+        se = scope._tags['se']
+    
+    if se == "tda":
+        print("\ntda")
+        event['fingerprint'] = [ '{{ default }}', se, RELEASE ]    
+    if se not in [None, "undefined"]:
+        print("\nse", se")
+        event['fingerprint'] = [ '{{ default }}', se]    
+
     return event
 
 def traces_sampler(sampling_context):


### PR DESCRIPTION
## Overview
This is the complement to client sdk fingerprinting done in React https://github.com/sentry-demos/application-monitoring/pull/34

The `se` tag was already being passed from the frontend, already parsed via request headers and set on scope as a tag (in app.before_request callback)

**New**
This PR parses the tag inside of before_send, and updates the fingerprint based on that.

**Note on Request Headers vs Query Params**
The se tag must be set via query params to the React and then sent via request headers. If you were hitting Python's /handled /unhandled endpoints directly (and skipping React)via Postman, then you'd have to include the se tag via request headers (or support would have to be added for something like localhost:8080/handled?se=will but I think that's overkill. Howe often would we really be trying to do that?)

Today, we don't run pytests that are hitting Flask or SpringBoot endpoints directly. We run pytests that hit React routes which end up calling Flask+SpringBoot. Even if we made pytests hitting Flask+SpringBoot directly, then you could just set the se tag in the request headers of those requests.

## Testing
`se:will`
[error link](https://sentry.io/organizations/testorg-az/discover/application-monitoring-python:8774f32bfd394e9c9108e0cb16031709/?field=title&field=event.type&field=project&field=se&field=timestamp&name=All+Events&query=url%3Ahttp%3A%2F%2Flocalhost%3A5000%2A+OR+url%3Ahttp%3A%2F%2Flocalhost%3A8080%2A+event.type%3Aerror+%21project%3Ajava&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
![image](https://user-images.githubusercontent.com/8920574/139344457-a63d74be-c677-449c-8638-cf8b4767072d.png)

`se:tda`
[error link](https://sentry.io/organizations/testorg-az/discover/application-monitoring-python:a77dc99d1047417f8d39f3b9c1110987/?field=title&field=event.type&field=project&field=se&field=timestamp&name=All+Events&query=url%3Ahttp%3A%2F%2Flocalhost%3A5000%2A+OR+url%3Ahttp%3A%2F%2Flocalhost%3A8080%2A+AND+event.type%3Aerror+%21project%3Ajava&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
![image](https://user-images.githubusercontent.com/8920574/139345726-c7091d0d-20d5-460a-a807-a26d5300158f.png)
