### PR TITLE
SSL Cert error workaround documentation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -49,3 +49,23 @@ How to stop it
 ps fjx
 kill -9 <PID of the script.sh>
 ```
+# Troubleshooting
+
+### SSL Cert Issues
+
+Problem: When locally running TDA tests, i.e. `py.test -s -n 4 desktop_web`, if you experience this error (or similar relating to SSL Cert):
+
+```
+E           urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='ondemand.us-west-1.saucelabs.com', port=443): Max retries exceeded with url: /wd/hub/session (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1091)')))
+
+venv/lib/python3.7/site-packages/urllib3/util/retry.py:574: MaxRetryError
+```
+
+<details>
+<summary>Click to toggle error screenshot</summary>
+
+![Screen Shot 2021-11-29 at 2 57 11 PM](https://user-images.githubusercontent.com/12092849/145083651-5479f05c-107f-4d46-a981-1c728679172f.png)
+
+</details>
+
+**Solution:** A workaround is to locally change the `SAUCELABS_PROTOCOL` constant in `conftest.py` from `https` to `http`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from dotenv import load_dotenv
 load_dotenv()
 DSN = os.getenv("DSN")
 ENVIRONMENT = os.getenv("ENVIRONMENT") or "production"
+SAUCELABS_PROTOCOL = "https://"
+
 print("ENV", ENVIRONMENT)
 print("DSN", DSN)
 
@@ -69,9 +71,9 @@ def desktop_web_driver(request, data_center):
     access_key = environ['SAUCE_ACCESS_KEY']
 
     if data_center and data_center.lower() == 'eu':
-        selenium_endpoint = "https://{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
+        selenium_endpoint = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
     else:
-        selenium_endpoint = "https://{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
+        selenium_endpoint = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
 
     caps = dict()
     caps.update(request.param)
@@ -134,9 +136,9 @@ def android_emu_driver(request, data_center):
     }
 
     if data_center and data_center.lower() == 'eu':
-        sauce_url = "https://{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
     else:
-        sauce_url = "https://{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
     driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
     driver.implicitly_wait(20)
@@ -168,9 +170,9 @@ def ios_sim_driver(request, data_center):
     }
 
     if data_center and data_center.lower() == 'eu':
-        sauce_url = "https://{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
     else:
-        sauce_url = "https://{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
     driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
     driver.implicitly_wait(20)


### PR DESCRIPTION
- Document how to handle an SSL Cert error that prevents one from running tests locally
- Small refactor to make the local fix for this error easier to make (1 line local change instead of 6)