### PR TITLE
Fix Before Send

### DIFF
--- a/flask/main.py
+++ b/flask/main.py
@@ -21,12 +21,12 @@ print("> RELEASE", RELEASE)
 print("> ENVIRONMENT", ENVIRONMENT)
 
 def before_send(event, hint):
-    
-    # 'se' tag was set in app.before_request
+    # 'se' tag may have been set in app.before_request
     se = None
     with sentry_sdk.configure_scope() as scope:
-        se = scope._tags['se']
-    
+        if 'se' in scope._tags:
+            se = scope._tags['se']
+
     if se == "tda":
         event['fingerprint'] = [ '{{ default }}', se, RELEASE ]
     elif se not in [None, "undefined"]:


### PR DESCRIPTION
## Done
This is not the final code but it was an experiment that verifies this fix. See Files Changed for the final code.


The '111111' and '222222' still execute (and the event gets sent to Sentry) as long as you check if the 'se' key is in the scope first. This means you are no longer required to send through the se tag in the request headers (as is the case with our React Native app calling Flask)

```
def before_send(event, hint):
    print("> 000000 code still executes...")
    
    # 'se' tag was set in app.before_request
    se = None
    with sentry_sdk.configure_scope() as scope:
        # THIS IS THE FIX
        if 'se' in scope._tags:
            se = scope._tags['se']

    print("> 111111 code still executes...")

    if se == "tda":
        event['fingerprint'] = [ '{{ default }}', se, RELEASE ]
    elif se not in [None, "undefined"]:
        event['fingerprint'] = [ '{{ default }}', se]    

    print("> 222222 code still executes...")
    return event
```
## Testing
I deployed to staging and found that hitting:

http://staging-application-monitoring-flask-dot-sales-engineering-sf.appspot.com/handled
http://staging-application-monitoring-flask-dot-sales-engineering-sf.appspot.com/unandled

causes these two errors (which means that before_send is not failing silently anymore): 
[error1](https://sentry.io/organizations/testorg-az/discover/will-flask:e7d47dd91e084e3bbf92b83976369649/?field=title&field=event.type&field=project&field=http.url&field=timestamp&name=All+Events&project=6112038&query=event.type%3Aerror&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
[error2](https://sentry.io/organizations/testorg-az/discover/will-flask:02c6241867f44d7c8c609f33c29d2ec5/?field=title&field=event.type&field=project&field=http.url&field=timestamp&name=All+Events&project=6112038&query=event.type%3Aerror&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
![image](https://user-images.githubusercontent.com/8920574/146576648-195510fd-8c93-4152-b61a-6cfe6b95da49.png)

and

https://staging-application-monitoring-react-dot-sales-engineering-sf.appspot.com/products to Checkout produced this Not Enough Inventory error:
https://sentry.io/organizations/testorg-az/discover/application-monitoring-python:5f8b9fbc4d0f44f5b662494481b56060/?field=title&field=event.type&field=project&field=http.url&field=timestamp&name=All+Events&project=5808655&query=event.type%3Aerror+http.url%3Ahttps%3A%2F%2Fstaging-application-monitoring-flask-dot-sales-engineering-sf.appspot.com%2Fcheckout&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29

## Todo
Find a way to set se tag in React Native tag. This PR does not fix that problem, but it at least allows React Native to cause the Checkout Error in Flask again. 