### PR TITLE
React Native Javascript Crashes in Homescreen Pytest

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,8 +4,8 @@ Runs automted tests against Sentry demos on GCP, in order to generate errors and
 ## Components / Moving parts
 - `conftest.py` -> Sauce Labs configuration (browsers) for frontend_tests
 - `backend_tests/backend_test.py` -> Hits /handled, /unhandled/, + /checkout backend demo APIs
-- Selectors for button elements in the React Native app can be found in Saucelabs via Sauce Labs Inspector...
-- [SauceLabs Inspector](https://github.com/appium/appium-inspector) download and launch this Desktop program, see img...TODO
+- Selectors for button elements in the React Native app can be found via connecting an Appium Inspector to your Saucelabs instance.
+- [SauceLabs Inspector](https://github.com/appium/appium-inspector) download and launch this Desktop program, get the JSON config from someone.
 
 # Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,6 +4,8 @@ Runs automted tests against Sentry demos on GCP, in order to generate errors and
 ## Components / Moving parts
 - `conftest.py` -> Sauce Labs configuration (browsers) for frontend_tests
 - `backend_tests/backend_test.py` -> Hits /handled, /unhandled/, + /checkout backend demo APIs
+- Selectors for button elements in the React Native app can be found in Saucelabs via Sauce Labs Inspector...
+- [SauceLabs Inspector](https://github.com/appium/appium-inspector) download and launch this Desktop program, see img...TODO
 
 # Tests
 
@@ -41,6 +43,7 @@ py.test -s -n 4 desktop_web
 How to run one test:
 ```
 py.test -s -n 4 desktop_web/test_homepage.py
+py.test -s -n 4 mobile_native/android_react_native/test_homescreen_react_native_android.py
 ```
 
 # To run "continuously" in VM

--- a/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -1,16 +1,24 @@
+import random
 def test_homescreen_react_native_android(android_react_native_emu_driver):
-    # Handled Exceptions - these do not increment the Crashes count in Release Health Capture Message, Capture Exception
-    # android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[3]/android.widget.TextView').click()
-    android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView').click()
+    # Handled Exceptions - This clicks the Handled Exception button in the app
+    # This error type does not increment the Crash Count for the release, 
+    # but the UI in Release dashboard separates from Handled vs Handled, so good to capture some of these, for having a more diverse data set.
+    # 40% of the time this will error.
+    if random.randint(1,10) < 3:
+        android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView').click()
 
-    # UnCaught Thrown Error - increments the Crashes count
-    android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView').click()
+    # Unhandled Exception - This clicks the Uncaught Thrown Error button in the app
+    # This error type increments the Crashes count for the release
+    # 40% of the time this will error.
+    if random.randint(1,10) < 3:
+        android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView').click()
 
-    # This did not work, despite using the right xpath from Appium Inspector.
+
+    # TODO - add more types of unhandled errors. This button not work, because the xpath could not be found, despite double checking in Appium Inpsector that it was the right one.
     # Unhandled Promise Rejection - increments the Crashes count
     # android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView').click()
     
-    # This may require a <TextView> in react-native instead of a <Text>
+    # TODO - select by something other than a xpath. This may require a <TextView> in react-native instead of a <Text>
     # android_react_native_emu_driver.find_element_by_xpath('//*[@text="Unhandled Promise Rejection"]').click()
 
 

--- a/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -1,25 +1,27 @@
 import random
+
 def test_homescreen_react_native_android(android_react_native_emu_driver):
-    # Handled Exceptions - This clicks the Handled Exception button in the app
+    # Handled Exceptions - This clicks the Handled Exception' button in the app
     # This error type does not increment the Crash Count for the release, 
     # but the UI in Release dashboard separates from Handled vs Handled, so good to capture some of these, for having a more diverse data set.
     # 40% of the time this will error.
     if random.randint(1,10) < 3:
         android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView').click()
 
-    # Unhandled Exception - This clicks the Uncaught Thrown Error button in the app
+    # Unhandled Exception - This clicks the 'Uncaught Thrown Error' button in the app
     # This error type increments the Crashes count for the release
     # 40% of the time this will error.
     if random.randint(1,10) < 3:
         android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView').click()
 
 
+    # TODO - select by something other than a xpath. This may require a <TextView> in react-native instead of a <Text>
+    # android_react_native_emu_driver.find_element_by_xpath('//*[@text="Unhandled Promise Rejection"]').click()
+
     # TODO - add more types of unhandled errors. This button not work, because the xpath could not be found, despite double checking in Appium Inpsector that it was the right one.
     # Unhandled Promise Rejection - increments the Crashes count
     # android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView').click()
-    
-    # TODO - select by something other than a xpath. This may require a <TextView> in react-native instead of a <Text>
-    # android_react_native_emu_driver.find_element_by_xpath('//*[@text="Unhandled Promise Rejection"]').click()
+
 
 
 

--- a/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -1,0 +1,15 @@
+def test_homescreen_react_native_android(android_react_native_emu_driver):
+
+    # TODO randomize how often these Crash Buttons get clicked or not, or else it'd be "0% Crash Free Sessions"
+    #      it may be counter-balanced by any healthy sessions from the Checkout test (it doesn't error if exactly 1 inventory is selected)
+    #      I could let this run for 24hrs (without randomization) to see what happens first, then tune and adjust.
+    # TODO could try a send to background/foreground cycle too and see how it affects things?
+
+    # Capture Message, Capture Exception
+    android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[3]/android.widget.TextView').click()
+    android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView').click()
+
+    # UnCaught Thrown Error 
+    android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView').click()
+
+    # TODO could try the Unhandled Promise Rejection and Native Crash as well

--- a/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -1,15 +1,18 @@
 def test_homescreen_react_native_android(android_react_native_emu_driver):
-
-    # TODO randomize how often these Crash Buttons get clicked or not, or else it'd be "0% Crash Free Sessions"
-    #      it may be counter-balanced by any healthy sessions from the Checkout test (it doesn't error if exactly 1 inventory is selected)
-    #      I could let this run for 24hrs (without randomization) to see what happens first, then tune and adjust.
-    # TODO could try a send to background/foreground cycle too and see how it affects things?
-
-    # Capture Message, Capture Exception
-    android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[3]/android.widget.TextView').click()
+    # Handled Exceptions - these do not increment the Crashes count in Release Health Capture Message, Capture Exception
+    # android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[3]/android.widget.TextView').click()
     android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView').click()
 
-    # UnCaught Thrown Error 
+    # UnCaught Thrown Error - increments the Crashes count
     android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView').click()
 
-    # TODO could try the Unhandled Promise Rejection and Native Crash as well
+    # This did not work, despite using the right xpath from Appium Inspector.
+    # Unhandled Promise Rejection - increments the Crashes count
+    # android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView').click()
+    
+    # This may require a <TextView> in react-native instead of a <Text>
+    # android_react_native_emu_driver.find_element_by_xpath('//*[@text="Unhandled Promise Rejection"]').click()
+
+
+
+    


### PR DESCRIPTION
## Overview
This adds additional unhandled errors to React Native Android's TDA.

This lays the groundwork for Release Health in React Native.

'Crash Free Rate' is no longer stuck at '100%' as this new pytest triggers unhandled errors from button clicks on the home screen.

The randomization rate for erroring is set to 40%. Side Note: I realized there is no way to make it error 10% some days and 50% other days, because if you constantly pick a random number 1 to 10 over a 24hr period, it's always going to average out to 5 (think about it), which would give you 50%. So better just to pick a percentage, and I chose 40%. The code is simpler this way too.

## Testing
Run it 10 times in a row, and should not get 10 crashes, because it only crashes 40% of the time.
```
py.test -s -n 4 mobile_native/android_react_native/test_homescreen_react_native_android.py
[release](https://sentry.io/organizations/testorg-az/releases/?project=5716557)
```
Starting crashes count: 14
Finishing crashes count: Y

Start
![image](https://user-images.githubusercontent.com/8920574/148961232-476d2e3d-4cd4-473e-8801-ff07f4639fea.png)

Finish
![image](https://user-images.githubusercontent.com/8920574/148965432-af224233-9e03-4ca1-a8e1-6d046b956ed4.png)

## Next
1. Could try sending to background and back to foreground, which would create more sessions. This may aid our mobile metrics data too. 

"session is managed in the native layer (java/ios)...if you're doing that for testing/generating data, best choice is to lower the "sessionTimeout" option...to like 1 second or something, then just put the app on the background and on the foreground again" -Bruno.

2. Select the element by a more permanent attribute rather than a xpath, like:
```
driver.find_element_by_xpath('//*[@text="Unhandled Promise Rejection"]')
```
But, this was unable to find the element, perhaps because [this](https://chase-seibert.github.io/blog/2017/01/06/appium-react-native-quickstart.html). Note that you'd have to upload a new APK to Github to try this. It also has an example with setting up an accessibility_id.