### PR TITLE
React Native iOS and Android Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add +2 quantity of a single item to Cart and purchase in order to trigger an Err
 
 
 ## Deploy
-This script deploys the flagship apps React + Flask. For deploying a single app to App Engine, check each platform's README for specific instructions.
+This script deploys the flagship apps React + Flask. For deploying a single app to App Engine, check each platform's README for specific instructions. Make sure all .env's and app.yaml's have correct values before deploying.
 ```
 ./deploy.sh
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,6 +44,7 @@ How to run one test:
 ```
 py.test -s -n 4 desktop_web/test_homepage.py
 py.test -s -n 4 mobile_native/android_react_native/test_homescreen_react_native_android.py
+py.test -s -n 4 mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
 ```
 
 # To run "continuously" in VM
@@ -81,3 +82,5 @@ venv/lib/python3.7/site-packages/urllib3/util/retry.py:574: MaxRetryError
 **Solution:** A workaround is to locally change the `SAUCELABS_PROTOCOL` constant in `conftest.py` from `https` to `http`.
 
 Note that handled errors will not increment the crash counts in Release Health. But the Release Health UI does separate Handled from Unhandled Issues.
+
+https://appium.io/docs/en/commands/device/app/launch-app/

--- a/tests/README.md
+++ b/tests/README.md
@@ -79,3 +79,5 @@ venv/lib/python3.7/site-packages/urllib3/util/retry.py:574: MaxRetryError
 </details>
 
 **Solution:** A workaround is to locally change the `SAUCELABS_PROTOCOL` constant in `conftest.py` from `https` to `http`.
+
+Note that handled errors will not increment the crash counts in Release Health. But the Release Health UI does separate Handled from Unhandled Issues.

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -18,7 +18,7 @@ def test_homepage(desktop_web_driver):
 
         for i in range(random.randrange(20)):
             # Randomize the Failure Rate between 1% and 40%
-            n = random.uniform(0.01, .04)
+            n = random.uniform(0.01, .4)
 
             # This query string is parsed by utils/errors.js wherever the 'crasher' function is used
             # and causes the page to periodically crash, for Release Health

--- a/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
@@ -1,0 +1,5 @@
+import random
+
+def test_captureexception_react_native_android(android_react_native_emu_driver):
+    btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView')
+    btn.click()

--- a/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
@@ -1,5 +1,8 @@
 import random
 
+# Handled Exception
+# This error type does not increment the Crash Count for the release, 
+# but the UI in Release dashboard separates from Handled vs Handled, so good to capture some of these, for having a more diverse data set.
 def test_captureexception_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
@@ -1,8 +1,5 @@
 import random
 
-# Handled Exception
-# This error type does not increment the Crash Count for the release, 
-# but the UI in Release dashboard separates from Handled vs Handled, so good to capture some of these, for having a more diverse data set.
 def test_captureexception_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[5]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/android_react_native/test_capturemessage_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_capturemessage_react_native_android.py
@@ -1,0 +1,5 @@
+import random
+
+def test_capturemessage_react_native_android(android_react_native_emu_driver):
+    btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[3]/android.widget.TextView')
+    btn.click()

--- a/tests/mobile_native/android_react_native/test_nativecrash_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_nativecrash_react_native_android.py
@@ -1,5 +1,5 @@
-import random
-
 def test_nativecrash_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[11]/android.widget.TextView')
     btn.click()
+    # launch app again or the error does not get sent to Sentry
+    android_react_native_emu_driver.launch_app()

--- a/tests/mobile_native/android_react_native/test_nativecrash_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_nativecrash_react_native_android.py
@@ -1,0 +1,5 @@
+import random
+
+def test_nativecrash_react_native_android(android_react_native_emu_driver):
+    btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[11]/android.widget.TextView')
+    btn.click()

--- a/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -1,7 +1,5 @@
 import random
 
-# Unhandled Exception - This clicks the 'Uncaught Thrown Error' button in the app
-# This error type increments the Crashes count for the release
 def test_uncaughtthrownerror_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -1,5 +1,7 @@
 import random
 
+# Unhandled Exception - This clicks the 'Uncaught Thrown Error' button in the app
+# This error type increments the Crashes count for the release
 def test_uncaughtthrownerror_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -1,5 +1,5 @@
-import random
-
 def test_uncaughtthrownerror_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView')
     btn.click()
+    # launch app again or the error does not get sent to Sentry
+    android_react_native_emu_driver.launch_app()

--- a/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -1,0 +1,5 @@
+import random
+
+def test_uncaughtthrownerror_react_native_android(android_react_native_emu_driver):
+    btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[7]/android.widget.TextView')
+    btn.click()

--- a/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -1,5 +1,3 @@
-import random
-
 def test_unhandledpromiserejection_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -1,7 +1,5 @@
 import random
 
-# Unhandled Exception - This clicks the 'Uncaught Thrown Error' button in the app
-# This error type increments the Crashes count for the release
 def test_unhandledpromiserejection_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -1,0 +1,5 @@
+import random
+
+def test_unhandledpromiserejection_react_native_android(android_react_native_emu_driver):
+    btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView')
+    btn.click()

--- a/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -1,5 +1,7 @@
 import random
 
+# Unhandled Exception - This clicks the 'Uncaught Thrown Error' button in the app
+# This error type increments the Crashes count for the release
 def test_unhandledpromiserejection_react_native_android(android_react_native_emu_driver):
     btn = android_react_native_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup[9]/android.widget.TextView')
     btn.click()

--- a/tests/mobile_native/ios_react_native/test_captureexception_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_captureexception_react_native_ios.py
@@ -1,0 +1,3 @@
+def test_captureexception_react_native_ios(ios_react_native_sim_driver):
+    btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Capture Exception")
+    btn.click()

--- a/tests/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
@@ -1,5 +1,3 @@
-def test_checkout_ios(ios_react_native_sim_driver):
-    ios_react_native_sim_driver.find_element_by_accessibility_id("Empower Plant").click()
-
-    btn = ios_react_native_sim_driver.find_element_by_xpath('(//XCUIElementTypeOther[@name="Add to Cart"])[1]')
+def test_capturemessage_react_native_ios(ios_react_native_sim_driver):
+    btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Capture Message")
     btn.click()

--- a/tests/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
@@ -1,0 +1,5 @@
+def test_checkout_ios(ios_react_native_sim_driver):
+    ios_react_native_sim_driver.find_element_by_accessibility_id("Empower Plant").click()
+
+    btn = ios_react_native_sim_driver.find_element_by_xpath('(//XCUIElementTypeOther[@name="Add to Cart"])[1]')
+    btn.click()

--- a/tests/mobile_native/ios_react_native/test_checkout_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_checkout_react_native_ios.py
@@ -1,4 +1,4 @@
-def test_checkout_ios(ios_react_native_sim_driver):
+def test_checkout_react_native_ios(ios_react_native_sim_driver):
     ios_react_native_sim_driver.find_element_by_accessibility_id("Empower Plant").click()
 
     cart_btn = ios_react_native_sim_driver.find_element_by_xpath('(//XCUIElementTypeOther[@name="Add to Cart"])[1]')

--- a/tests/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
@@ -1,3 +1,5 @@
 def test_nativecrash_react_native_ios(ios_react_native_sim_driver):
     btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Native Crash")
     btn.click()
+    # launch app again or the error does not get sent to Sentry
+    ios_react_native_sim_driver.launch_app()

--- a/tests/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
@@ -1,0 +1,3 @@
+def test_nativecrash_react_native_ios(ios_react_native_sim_driver):
+    btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Native Crash")
+    btn.click()

--- a/tests/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
@@ -1,3 +1,5 @@
 def test_uncaughtthrownerror_react_native_ios(ios_react_native_sim_driver):
     btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Uncaught Thrown Error")
     btn.click()
+    # launch app again or the error does not get sent to Sentry
+    ios_react_native_sim_driver.launch_app()

--- a/tests/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
@@ -1,0 +1,3 @@
+def test_uncaughtthrownerror_react_native_ios(ios_react_native_sim_driver):
+    btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Uncaught Thrown Error")
+    btn.click()

--- a/tests/mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
@@ -1,0 +1,3 @@
+def test_unhandledpromiserejection_react_native_ios(ios_react_native_sim_driver):
+    btn = ios_react_native_sim_driver.find_element_by_accessibility_id("Unhandled Promise Rejection")
+    btn.click()


### PR DESCRIPTION
## Overview
RN/iOS needed more tests
RN/Android needed homescreen to be split into multiple tests, per each button.

## Testing iOS

py.test -s -n 4 mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
[event](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:40617b96d9ee4164a5b3d30040c02b36/?field=title&field=event.type&field=app.device&field=user.display&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction+event.type%3Adefault&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

py.test -s -n 4 mobile_native/ios_react_native/test_captureexception_react_native_ios.py
[event](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:6ce82bd165764f069cd743fd0e1ecd7d/?field=title&field=event.type&field=app.device&field=user.display&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

py.test -s -n 4 mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
[can't get this one to work, Loom Video](https://www.loom.com/share/8651c3e411124ed0ba8b8813a8b4af10)

py.test -s -n 4 mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
[event](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:ec9c09d5859947b68c3a3f545e536eae/?field=title&field=event.type&field=app.device&field=user.display&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

py.test -s -n 4 mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
[can't get this one to work, Loom Video](https://www.loom.com/share/47b7d6205d5443a79377baef676bd50e) maybe the app needs to be re-launced?

All errors appear in Sentry when you trigger them on a virtual RN device on your macbook, but 2 of them are not working when triggered from the Saucelabs hosted virtual RN device.

**Update Jan24th 202**2 - the above 2 problems were fixed by including driver.launch_app() to re-launch the app. Here's the [nativecrash](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:2c2498416345435489405ead962dde78/?field=title&field=event.type&field=sdk.name&field=user.display&field=timestamp&name=All+Events&project=5716557&query=%21title%3A%22Error%3A+500+-++INTERNAL+SERVER+ERROR%22+%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&widths=479&yAxis=count%28%29) and the [uncaughtthrownerror](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:9c14c0f603944800b19cb9001202d0a9/?field=title&field=event.type&field=sdk.name&field=user.display&field=timestamp&name=All+Events&project=5716557&query=%21title%3A%22Error%3A+500+-++INTERNAL+SERVER+ERROR%22+%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&widths=479&yAxis=count%28%29)

## Testing Android
py.test -s -n 4 mobile_native/android_react_native/test_capturemessage_react_native_android.py
[event](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:a4b8e6305db0435cae827fd6d2da13b1/?field=title&field=event.type&field=app.device&field=user.display&field=os&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=151&yAxis=count%28%29)

py.test -s -n 4 mobile_native/android_react_native/test_captureexception_react_native_android.py
[event](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:51bab9f65cc043d29630c5b6dee2e43a/?field=title&field=event.type&field=app.device&field=user.display&field=os&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction+os%3A%22Android+10%22&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=151&yAxis=count%28%29)

py.test -s -n 4 mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
can't get this one to work ([but it works from test_homescreen_react_native_android.py](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:45f5c4644b254f668052e496b9260047/?field=title&field=event.type&field=app.device&field=user.display&field=os&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction+os%3A%22Android+10%22&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=151&yAxis=count%28%29))

py.test -s -n 4 mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
[event](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:34e2a06fa46348219f73e9d33044ab60/?field=title&field=event.type&field=app.device&field=user.display&field=os&field=timestamp&name=All+Events&project=5716557&query=%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&widths=-1&widths=-1&widths=-1&widths=151&yAxis=count%28%29)

py.test -s -n 4 mobile_native/android_react_native/test_nativecrash_react_native_android.py
can't get this one to work ([saucelabs test](https://app.saucelabs.com/tests/99c5d8d92a914ead9cea2198919915c0), maybe the app needs to be re-launched?)

**Update Jan24th 2022** - The above 2 problems were fixed by adding driver.launch_app(). The [nativecrash](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:075d8742d3414e258ac485b2af702774/?field=title&field=os&field=sdk.name&field=error.handled&field=timestamp&name=All+Events&project=5716557&query=%21title%3A%22Error%3A+500+-++INTERNAL+SERVER+ERROR%22+%21event.type%3Atransaction+os%3A%22Android+10%22&sort=-timestamp&statsPeriod=1h&widths=479&yAxis=count%28%29) and the [uncaughtthrownerror](https://sentry.io/organizations/testorg-az/discover/dustin-react-native:ee9a34f28169413d8b11ac919279b6f0/?field=title&field=os&field=sdk.name&field=error.handled&field=timestamp&name=All+Events&project=5716557&query=%21title%3A%22Error%3A+500+-++INTERNAL+SERVER+ERROR%22+%21event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&widths=479&yAxis=count%28%29).