### PR TITLE
Android Native Tests for buttons

### DIFF
--- a/tests/mobile_native/android/test_anr_android.py
+++ b/tests/mobile_native/android/test_anr_android.py
@@ -5,15 +5,6 @@ def test_anr_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()
 
+    # TODO get the event to send to Sentry.io
     time.sleep(10)
-
     android_emu_driver.launch_app()
-
-'''
-py.test -s -n 4 mobile_native/android/test_unhandlederror_android.py
-py.test -s -n 4 mobile_native/android/test_unhandlederror2_android.py
-py.test -s -n 4 mobile_native/android/test_handlederror_android.py
-py.test -s -n 4 mobile_native/android/test_anr_android.py
-py.test -s -n 4 mobile_native/android/test_nativecrash_android.py
-py.test -s -n 4 mobile_native/android/test_nativemessage_android.py
-'''

--- a/tests/mobile_native/android/test_anr_android.py
+++ b/tests/mobile_native/android/test_anr_android.py
@@ -1,7 +1,4 @@
 # Application Not Responding button
 def test_anr_android(android_emu_driver):
-    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()
-    
-    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
-    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_anr_android.py
+++ b/tests/mobile_native/android/test_anr_android.py
@@ -1,0 +1,7 @@
+# Application Not Responding button
+def test_anr_android(android_emu_driver):
+    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn.click()
+    
+    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
+    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_anr_android.py
+++ b/tests/mobile_native/android/test_anr_android.py
@@ -1,4 +1,19 @@
+import time
+
 # Application Not Responding button
 def test_anr_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()
+
+    time.sleep(10)
+
+    android_emu_driver.launch_app()
+
+'''
+py.test -s -n 4 mobile_native/android/test_unhandlederror_android.py
+py.test -s -n 4 mobile_native/android/test_unhandlederror2_android.py
+py.test -s -n 4 mobile_native/android/test_handlederror_android.py
+py.test -s -n 4 mobile_native/android/test_anr_android.py
+py.test -s -n 4 mobile_native/android/test_nativecrash_android.py
+py.test -s -n 4 mobile_native/android/test_nativemessage_android.py
+'''

--- a/tests/mobile_native/android/test_anr_android.py
+++ b/tests/mobile_native/android/test_anr_android.py
@@ -1,6 +1,7 @@
 import time
-
+import pytest
 # Application Not Responding button
+@pytest.mark.skip(reason="not working")
 def test_anr_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()

--- a/tests/mobile_native/android/test_handlederror_android.py
+++ b/tests/mobile_native/android/test_handlederror_android.py
@@ -1,0 +1,7 @@
+# Clicks the Handled Error button that says ArrayIndexOutOfBoundsException
+def test_handlederror_android(android_emu_driver):
+    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn.click()
+    
+    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
+    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_handlederror_android.py
+++ b/tests/mobile_native/android/test_handlederror_android.py
@@ -1,7 +1,4 @@
 # Clicks the Handled Error button that says ArrayIndexOutOfBoundsException
 def test_handlederror_android(android_emu_driver):
-    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[3]')
     btn.click()
-    
-    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
-    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_nativecrash_android.py
+++ b/tests/mobile_native/android/test_nativecrash_android.py
@@ -1,4 +1,10 @@
+import time
+
 # NDK/C++ Native Crash SIGSEGV button
 def test_nativecrash_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()
+
+    time.sleep(5)
+    
+    android_emu_driver.launch_app()

--- a/tests/mobile_native/android/test_nativecrash_android.py
+++ b/tests/mobile_native/android/test_nativecrash_android.py
@@ -1,7 +1,4 @@
 # NDK/C++ Native Crash SIGSEGV button
 def test_nativecrash_android(android_emu_driver):
-    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()
-    
-    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
-    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_nativecrash_android.py
+++ b/tests/mobile_native/android/test_nativecrash_android.py
@@ -5,6 +5,6 @@ def test_nativecrash_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()
 
+    # TODO get the event to send to Sentry.io
     time.sleep(5)
-    
     android_emu_driver.launch_app()

--- a/tests/mobile_native/android/test_nativecrash_android.py
+++ b/tests/mobile_native/android/test_nativecrash_android.py
@@ -1,6 +1,7 @@
 import time
-
+import pytest
 # NDK/C++ Native Crash SIGSEGV button
+@pytest.mark.skip(reason="not working")
 def test_nativecrash_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
     btn.click()

--- a/tests/mobile_native/android/test_nativecrash_android.py
+++ b/tests/mobile_native/android/test_nativecrash_android.py
@@ -1,0 +1,7 @@
+# NDK/C++ Native Crash SIGSEGV button
+def test_nativecrash_android(android_emu_driver):
+    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn.click()
+    
+    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
+    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_nativemessage_android.py
+++ b/tests/mobile_native/android/test_nativemessage_android.py
@@ -1,4 +1,10 @@
 # NDK/C++ Native Message button
 def test_nativemessage_android(android_emu_driver):
+    # scroll down first, so the nativemessage button can become visible
+    bottom_of_screen_element = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[4]')
+    top_of_screen_element = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[1]')
+    android_emu_driver.scroll(bottom_of_screen_element, top_of_screen_element)
+
+    # nativemessage button
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[5]')
     btn.click()

--- a/tests/mobile_native/android/test_nativemessage_android.py
+++ b/tests/mobile_native/android/test_nativemessage_android.py
@@ -1,0 +1,7 @@
+# NDK/C++ Native Message button
+def test_nativemessage_android(android_emu_driver):
+    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn.click()
+    
+    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
+    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_nativemessage_android.py
+++ b/tests/mobile_native/android/test_nativemessage_android.py
@@ -1,7 +1,4 @@
 # NDK/C++ Native Message button
 def test_nativemessage_android(android_emu_driver):
-    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[5]')
     btn.click()
-    
-    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
-    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_unhandlederror2_android.py
+++ b/tests/mobile_native/android/test_unhandlederror2_android.py
@@ -1,0 +1,4 @@
+# Clicks the Handled Error button that says RTE and Strip PII
+def test_handlederror_android(android_emu_driver):
+    btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[2]')
+    btn.click()

--- a/tests/mobile_native/android/test_unhandlederror2_android.py
+++ b/tests/mobile_native/android/test_unhandlederror2_android.py
@@ -1,4 +1,6 @@
 # Clicks the Handled Error button that says RTE and Strip PII
-def test_handlederror_android(android_emu_driver):
+def test_unhandlederror2_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[2]')
     btn.click()
+
+    android_emu_driver.launch_app()

--- a/tests/mobile_native/android/test_unhandlederror_android.py
+++ b/tests/mobile_native/android/test_unhandlederror_android.py
@@ -2,3 +2,5 @@
 def test_unhandlederror_android(android_emu_driver):
     btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[1]')
     btn.click()
+    
+    android_emu_driver.launch_app()

--- a/tests/mobile_native/android/test_unhandlederror_android.py
+++ b/tests/mobile_native/android/test_unhandlederror_android.py
@@ -1,0 +1,7 @@
+# Clicks the Unhandled Error button that says ArithmeticException
+def test_unhandlederror_android(android_emu_driver):
+    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn.click()
+    
+    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
+    # add_to_cart_btn.click()

--- a/tests/mobile_native/android/test_unhandlederror_android.py
+++ b/tests/mobile_native/android/test_unhandlederror_android.py
@@ -1,7 +1,4 @@
 # Clicks the Unhandled Error button that says ArithmeticException
 def test_unhandlederror_android(android_emu_driver):
-    btn = android_emu_driver.find_element_by_accessibility_id('').click()
+    btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.widget.LinearLayout/android.widget.ScrollView/android.widget.LinearLayout/android.widget.Button[1]')
     btn.click()
-    
-    # add_to_cart_btn = android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.view.ViewGroup/android.widget.FrameLayout[2]/android.view.ViewGroup/android.widget.LinearLayout/android.widget.FrameLayout/androidx.recyclerview.widget.RecyclerView/android.widget.LinearLayout[1]/android.widget.LinearLayout/android.widget.LinearLayout/android.widget.Button')
-    # add_to_cart_btn.click()


### PR DESCRIPTION
## Overview
We had a test for Checkout but not for the rest of the buttons which cause different error types.

## Testing
These commands were run
```
py.test -s -n 4 mobile_native/android/test_unhandlederror_android.py
py.test -s -n 4 mobile_native/android/test_unhandlederror2_android.py
py.test -s -n 4 mobile_native/android/test_handlederror_android.py
py.test -s -n 4 mobile_native/android/test_anr_android.py
py.test -s -n 4 mobile_native/android/test_nativecrash_android.py
py.test -s -n 4 mobile_native/android/test_nativemessage_android.py
```
[Unhandlederror](https://sentry.io/organizations/testorg-az/discover/paranoid-android:82f30a9f6cec4867b4c6a9950d892e5d/?field=title&field=event.type&field=sdk.version&field=release&field=timestamp&name=All+Events&project=1801383&query=event.type%3Aerror&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

[Unhandlederror2](https://sentry.io/organizations/testorg-az/discover/paranoid-android:47e20eaab00d4229bc813aa8c3c5ac5f/?field=title&field=event.type&field=sdk.version&field=release&field=timestamp&name=All+Events&project=1801383&query=event.type%3Aerror&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

[Handlederror](https://sentry.io/organizations/testorg-az/discover/paranoid-android:91811badb04844b8ae707676c057873b/?field=title&field=event.type&field=sdk.version&field=release&field=timestamp&name=All+Events&project=1801383&query=event.type%3Aerror&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

ANR is not getting sent to Sentry. TODO

NativeCrash is not getting sent to Sentry. TODO

[NativeMessage](https://sentry.io/organizations/testorg-az/discover/paranoid-android:7074ed5ab12142ce386b6d8fe71a5c5d/?field=title&field=event.type&field=sdk.version&field=release&field=timestamp&name=All+Events&project=1801383&query=event.type%3Adefault&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)