### PR TITLE
Release Versioning Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ Run `gcloud auth login` if it asks you to authenticate, or insert YubiKey.
 ## Deploy to Staging
 Update the app engine service name in the following places:  
 ```
+// required
 react/app.yaml to staging-application-monitoring-javascript  
 react/.env to staging-application-monitoring-express, -flask, -springboot
-
-react/.env REACT_APP_BACKEND with updated DSN
-flask/.env FLASK_APP_DSN with updated DSN
-springboot/src/main/resources/application.properties with DSN
-
 flask/app.yaml to staging-application-monitoring-javascript 
 express/app.yaml to staging-application-monitoring-node
 spring-boot/src/main/appengine/app.yaml to staging-springboot
 
-deploy.sh's SENTRY_PROJECT optionally
+// optional
+react/.env REACT_APP_BACKEND with updated DSN
+flask/.env FLASK_APP_DSN with updated DSN
+springboot/src/main/resources/application.properties with updated DSN
+deploy.sh's SENTRY_PROJECT with updated value
 ```
 Then run deploy.sh for deploying the flagship app (React to Flask) together, or deploy only the individual apps that you need (check the README for each platform). 
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,17 @@ Run `gcloud auth login` if it asks you to authenticate, or insert YubiKey.
 Update the app engine service name in the following places:  
 ```
 react/app.yaml to staging-application-monitoring-javascript  
-react/.env to staging-application-monitoring-express, -flask, -springboot.
-  
+react/.env to staging-application-monitoring-express, -flask, -springboot
+
+react/.env REACT_APP_BACKEND with updated DSN
+flask/.env FLASK_APP_DSN with updated DSN
+springboot/src/main/resources/application.properties with DSN
+
 flask/app.yaml to staging-application-monitoring-javascript 
 express/app.yaml to staging-application-monitoring-node
 spring-boot/src/main/appengine/app.yaml to staging-springboot
+
+deploy.sh's SENTRY_PROJECT optionally
 ```
 Then run deploy.sh for deploying the flagship app (React to Flask) together, or deploy only the individual apps that you need (check the README for each platform). 
 
@@ -130,6 +136,9 @@ gcloud topic configurations
 gcloud auth
 gcloud auth application-default
 gcloud auth login
+gcloud auth list
+gcloud config set account `ACCOUNT`
+gcloud config list, to display current account
 ```
 
 ### Other

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@ RELEASE=`./release.sh`
 echo $RELEASE
 
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=application-monitoring-javascript
+SENTRY_PROJECT=will-react
 PREFIX=static/js
 
 cd react

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@ RELEASE=`./release.sh`
 echo $RELEASE
 
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=will-react
+SENTRY_PROJECT=application-monitoring-javascript
 PREFIX=static/js
 
 cd react

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -46,6 +46,27 @@ if (window.location.hostname === "localhost") {
 let BACKEND_URL
 const DSN = process.env.REACT_APP_DSN
 const RELEASE = process.env.REACT_APP_RELEASE
+var dateObj = new Date();
+var month = dateObj.getUTCMonth() + 1; //months from 1-12
+var day = dateObj.getUTCDate();
+var week
+if (day <= 7) {
+  week = 1
+} else if (day <= 14) {
+  week = 2
+} else if (day <= 21) {
+  week = 3
+} else if (day <= 28) {
+  week = 4
+} else if (day <= 35) {
+  week = 5
+}
+var year = dateObj.getUTCFullYear();
+year = year.toString().slice(-2)
+
+const newrelease = year + "." + month + "." + week;
+console.log("> newrelease", newrelease)
+
 console.log("ENVIRONMENT", ENVIRONMENT)
 console.log("RELEASE", RELEASE)
 

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -8,6 +8,7 @@ import { createBrowserHistory } from 'history';
 import { Router, Switch, Route } from 'react-router-dom';
 import { crasher } from './utils/errors'
 import { determineBackendType, determineBackendUrl } from './utils/backendrouter'
+import release from './utils/release'
 
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware, compose } from 'redux'
@@ -45,27 +46,7 @@ if (window.location.hostname === "localhost") {
 
 let BACKEND_URL
 const DSN = process.env.REACT_APP_DSN
-const RELEASE = process.env.REACT_APP_RELEASE
-var dateObj = new Date();
-var month = dateObj.getUTCMonth() + 1; //months from 1-12
-var day = dateObj.getUTCDate();
-var week
-if (day <= 7) {
-  week = 1
-} else if (day <= 14) {
-  week = 2
-} else if (day <= 21) {
-  week = 3
-} else if (day <= 28) {
-  week = 4
-} else if (day <= 35) {
-  week = 5
-}
-var year = dateObj.getUTCFullYear();
-year = year.toString().slice(-2)
-
-const newrelease = year + "." + month + "." + week;
-console.log("> newrelease", newrelease)
+const RELEASE = release() || process.env.REACT_APP_RELEASE
 
 console.log("ENVIRONMENT", ENVIRONMENT)
 console.log("RELEASE", RELEASE)

--- a/react/src/utils/release.js
+++ b/react/src/utils/release.js
@@ -1,0 +1,25 @@
+const release = () => {
+
+    var date = new Date();
+    var month = date.getUTCMonth() + 1; //months from 1-12
+    var day = date.getUTCDate();
+    
+    var week
+    if (day <= 7) {
+        week = 1
+    } else if (day <= 14) {
+        week = 2
+    } else if (day <= 21) {
+        week = 3
+    } else if (day <= 28) {
+        week = 4
+    } else if (day <= 35) {
+        week = 5
+    }
+    
+    var year = date.getUTCFullYear().toString().slice(-2);
+
+    return year + "." + month + "." + week;
+}
+
+export default release

--- a/release.sh
+++ b/release.sh
@@ -3,13 +3,16 @@
 # /react and /flask both have a run.sh script that utilizes this code
 day=$(date +%d)
 month=$(date +%-m)
+year=$(date +%y)
 if [ "$day" -ge 0 ] && [ "$day" -le 7 ]; then
   week=1
 elif [ "$day" -ge 8 ] &&  [ "$day" -le 14 ]; then
   week=2
 elif [ "$day" -ge 15 ] &&  [ "$day" -le 21 ]; then
   week=3
-elif [ "$day" -ge 22 ]; then
+elif [ "$day" -ge 22 ] && [ "$day" -le 28 ]; then
   week=4
+elif [ "$day" -ge 29 ] && [ "$day" -le 35 ]; then
+  week=5
 fi
-echo "$month.$week"
+echo "$year.$month.$week"


### PR DESCRIPTION
## Overview
The ./deploy.sh script is run daily. This will take care of uploading sourcemaps for the right release YY-M-Week. release.sh was updated to include the year. Running it "every 7 days" could get hard to time the cronjob with the exact 1st day of the week, so decided to run it daily instead for simplicity.

react/src/index.js was updated so that it uses a function `release()` to create the release in form YY-M-W. Every time the javascript app bundle is served, it will compute the release number dynamically.

## Testing
[transaction with release 22.2.1](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:c95a70b336f0494b87ee43a3b10e5b25/?field=title&field=event.type&field=project&field=release&field=timestamp&name=All+Events&project=6089805&project=5808623&project=5808655&project=6090082&query=se%3Awill+event.type%3Atransaction&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

## Note
Application Monitoring Javascript is the only project getting a release in the form of YY-MM-W because if all backend platforms had YY-MM-WW then there'd be too many empty looking releases in the Release Health dashboard. The release health story is for Mobile and Front End Web. It's also not realistic to have the same app versions for all of your apps and repo's. Typically they're different.

deployl.sh's 'gcloud' commands do not complete, because the gcloud sdk is not authenticated (gcloud auth login). You could also comment them out. I wanted to leave the deploy.sh script as is as it's still useful for manual deployments. Did not want to modularize it into a sentry-cli.sh and deploy.sh. Not worth having to follow 2 separate scripts when 1 still gets the job done for both use cases. Could change it in future if need be.