### PR TITLE
Semantic Versioning - Package@Version

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -46,7 +46,7 @@ if (window.location.hostname === "localhost") {
 
 let BACKEND_URL
 const DSN = process.env.REACT_APP_DSN
-const RELEASE = release() || process.env.REACT_APP_RELEASE
+const RELEASE = release("application.monitoring.javascript") || process.env.REACT_APP_RELEASE
 
 console.log("ENVIRONMENT", ENVIRONMENT)
 console.log("RELEASE", RELEASE)

--- a/react/src/utils/release.js
+++ b/react/src/utils/release.js
@@ -1,4 +1,4 @@
-const release = () => {
+const release = (packageName) => {
 
     var date = new Date();
     var month = date.getUTCMonth() + 1; //months from 1-12
@@ -19,7 +19,8 @@ const release = () => {
     
     var year = date.getUTCFullYear().toString().slice(-2);
 
-    return year + "." + month + "." + week;
+    // package@version
+    return `${packageName}@${year}.${month}.${week}`
 }
 
 export default release


### PR DESCRIPTION
## Overview
Now we see Package Name with the release.
![image](https://user-images.githubusercontent.com/8920574/152415654-aa43d99d-5a94-4116-825c-9d11eb0fd6a2.png)

Notice that only the release with Semantic Versioning is filterable by `release.version:22.2*`
![image](https://user-images.githubusercontent.com/8920574/152415722-eacbf914-b28e-4361-acb9-531a25e522cf.png)

and see it here
![image](https://user-images.githubusercontent.com/8920574/152415840-e70e1093-5894-4ebb-97ae-95b5344497d0.png)

and see it here
![image](https://user-images.githubusercontent.com/8920574/152414866-46c232df-9653-4985-a55b-755e1c531298.png)

## Testing
[Trace ID: b3e0699afce24088a2c1dc31cf3cbe64](https://sentry.io/organizations/testorg-az/performance/trace/b3e0699afce24088a2c1dc31cf3cbe64/?pageEnd=2022-02-04T07%3A23%3A53.200&pageStart=2022-02-03T07%3A23%3A53.200)

I deployed this a moment ago, it's starting to get errors+tx's from TDA, you can track the Release here
https://sentry.io/organizations/testorg-az/releases/application.monitoring.javascript%4022.2.1/?project=5808623