### PR TITLE
standardized OS X versions for selenium

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ desktop_browsers = [
         "sauce:options": {}
     }, {
         "seleniumVersion": '3.4.0',
-        "platform": "OS X 10.11",
+        "platform": "OS X 10.13",
         "browserName": "chrome",
         "version": "latest",
         "sauce:options": {}


### PR DESCRIPTION
## Problem
React transactions getting dropped in Application Monitoring when it calls Express Application Monitoring backend.
React<>Express transactions not linked via Distributed Tracing

## Solution
Bring up the OS X version in selenium to 10.13 which matches what was working in other successful OS X tests (e.g. OS X with Safari, 10.13).

Check the recent MacOSX:Chrome transactions from React to Express, they're now linked by distributed tracing.

## Testing
[Discover Query](https://sentry.io/organizations/testorg-az/discover/results/?display=top5&field=browser.name&field=os.name&field=count%28%29&name=Error%3A+Not+enough+inventory+for+product&project=5808623&query=se%3Atda&sort=-browser.name&statsPeriod=1h&yAxis=count%28%29) for last Hour
![image](https://user-images.githubusercontent.com/8920574/153952800-590ac8ab-b6b5-4580-923e-80d232b06980.png)

If you see past 24Hours right now, you'll these transactions only started an hour or two ago.

[Discover Query2](https://sentry.io/organizations/testorg-az/discover/results/?display=top5&field=browser.name&field=os.name&field=title&field=timestamp&name=Error%3A+Not+enough+inventory+for+product&project=5808623&query=se%3Atda+browser.name%3AChrome+os.name%3A%22Mac+OS+X%22+event.type%3Atransaction&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29) - you'll see this is the first time in about 2 months these transactions are coming in.
![image](https://user-images.githubusercontent.com/8920574/153953097-43833acc-c0fe-40f3-8e3e-51def92c46ee.png)


