### PR TITLE
Fix Release and Package Name

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,7 @@
 RELEASE=`./release.sh`
+PACKAGE_NAME=application.monitoring.javascript
+
+RELEASE=$PACKAGE_NAME@$RELEASE
 echo $RELEASE
 
 SENTRY_ORG=testorg-az

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -75,7 +75,7 @@ Sentry.init({
 
     if (se === "tda") {
       // Release Health
-      event.fingerprint = ['{{ default }}', se, process.env.REACT_APP_RELEASE ];
+      event.fingerprint = ['{{ default }}', se, RELEASE ];
     } else if (se) {
       event.fingerprint = ['{{ default }}', se ];
     }


### PR DESCRIPTION
## Problem
**Problem1**
Our deploy script used sentry-cli but the release did not have the 'package name' in it for Semantic Versioning. Hence, source maps were getting uploaded to the '22.2.3' release but not the 'packageName@22.2.3' release.

Over the past 2 weeks I observed there were duplicate releases for both 22.2.2 and 22.2.3 getting created. One would have events in it, and the other would not.

**Problem2**
Also, fingerprinting in beforeSend was still using process.env.REACT_APP_RELEASE which was based on a .env file, which was a static value. Hence new releases 22.2.1 and 22.2.3 were still grouping with an outdated fingerprint.

## Solution
**Solution1**
Both sentry-cli and the dynamically created Release in src/index.js now have packageName@release.

**Solution2**
Fingerprinting in beforeSend uses the RELEASE variable that's computed every time the web app is loaded (dynamically).

## Testing
**Solution1**
Release 22.2.3 now has source maps.
https://sentry.io/organizations/testorg-az/releases/application.monitoring.javascript%4022.2.3/?project=5808623

Note - I removed the empty 22.2.2 and 22.2.3 releases, so that's why they're not there.

But now, when 22.2.4 happens, there should only be 1 release for that getting created, and not two.

**Solution2**
[Event in 22.2.3 release with a 22.2.3 fingerprint](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:71f0d7a8c72a44a081a11aa3574fb10e/?field=title&field=event.type&field=project&field=release&field=timestamp&name=All+Events&project=5808623&query=event.type%3Aerror&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29)
<img width="588" alt="image" src="https://user-images.githubusercontent.com/8920574/154341118-131a91e1-1b7a-45d4-aa6a-c9e65f31243d.png">
