### PR TITLE
Database Connection Errors

### DIFF
--- a/flask/db.py
+++ b/flask/db.py
@@ -18,6 +18,9 @@ CLOUD_SQL_CONNECTION_NAME = os.environ.get("CLOUD_SQL_CONNECTION_NAME")
 class DatabaseConnectionError (Exception):
     pass
 
+# error type was 'Error' so using the error message here so it's more specific
+UNPACK_FROM_ERROR="unpack_from requires a buffer of at least 5 bytes for unpacking 5 bytes at offset"
+
 if FLASK_ENV == "test":
     print("> ENVIRONMENT test ")
     db = create_engine('postgresql://' + USERNAME + ':' + PASSWORD + '@' + HOST + ':5432/' + DATABASE)
@@ -71,7 +74,7 @@ def get_products():
     except BrokenPipeError as err:
         raise DatabaseConnectionError('get_products')
     except Exception as err:
-        if "unpack_from requires a buffer of at least 5 bytes for unpacking 5 bytes at offset" in err:
+        if UNPACK_FROM_ERROR in err:
             raise DatabaseConnectionError('get_products')
         else:
             raise(err)
@@ -98,7 +101,7 @@ def get_products_join():
     except BrokenPipeError as err:
         raise DatabaseConnectionError('get_products_join')
     except Exception as err:
-        if "unpack_from requires a buffer of at least 5 bytes for unpacking 5 bytes at offset" in err:
+        if UNPACK_FROM_ERROR in err:
             raise DatabaseConnectionError('get_products')
         else:
             raise(err)

--- a/flask/db.py
+++ b/flask/db.py
@@ -102,7 +102,7 @@ def get_products_join():
         raise DatabaseConnectionError('get_products_join')
     except Exception as err:
         if UNPACK_FROM_ERROR in err:
-            raise DatabaseConnectionError('get_products')
+            raise DatabaseConnectionError('get_products_join')
         else:
             raise(err)
 

--- a/flask/main.py
+++ b/flask/main.py
@@ -55,6 +55,13 @@ sentry_sdk.init(
 app = Flask(__name__)
 CORS(app)
 
+
+# TODO CLASS
+# DatabaseConnectionError: get_inventory
+class DatabaseConnectionError (Exception):
+    pass
+
+
 @app.route('/checkout', methods=['POST'])
 def checkout():
     order = json.loads(request.data)
@@ -68,6 +75,9 @@ def checkout():
     except Exception as err:
         print(err)
         sentry_sdk.capture_exception(err)
+        # TODO
+        throw DatabaseConnectionError('')
+        return # a response, 200
     print("> /checkout inventory", inventory)
 
     with sentry_sdk.start_span(op="process_order", description="function"):

--- a/flask/main.py
+++ b/flask/main.py
@@ -55,13 +55,6 @@ sentry_sdk.init(
 app = Flask(__name__)
 CORS(app)
 
-
-# TODO CLASS
-# DatabaseConnectionError: get_inventory
-class DatabaseConnectionError (Exception):
-    pass
-
-
 @app.route('/checkout', methods=['POST'])
 def checkout():
     order = json.loads(request.data)
@@ -76,8 +69,8 @@ def checkout():
         print(err)
         sentry_sdk.capture_exception(err)
         # TODO
-        throw DatabaseConnectionError('')
-        return # a response, 200
+        # throw DatabaseConnectionError('')
+        # return # a response, 200
     print("> /checkout inventory", inventory)
 
     with sentry_sdk.start_span(op="process_order", description="function"):

--- a/flask/main.py
+++ b/flask/main.py
@@ -66,11 +66,8 @@ def checkout():
         with sentry_sdk.start_span(op="/checkout.get_inventory", description="function"):
             inventory = get_inventory(cart)
     except Exception as err:
-        print(err)
-        sentry_sdk.capture_exception(err)
-        # TODO
-        # throw DatabaseConnectionError('')
-        # return # a response, 200
+        raise(err)
+
     print("> /checkout inventory", inventory)
 
     with sentry_sdk.start_span(op="process_order", description="function"):

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -1,5 +1,5 @@
 blinker==1.4
-flask==1.1.2
+flask==2.0.3
 flask-cors==3.0.10
 gunicorn==20.1.0
 numpy==1.20.2
@@ -9,4 +9,3 @@ python-dotenv==0.12.0
 pytz==2020.4
 sentry-sdk==1.5.1
 sqlalchemy==1.3.15
-


### PR DESCRIPTION
## Overview
There are 3 different issues surfacing when Database connection and query problems occur. These problems occur intermittently. The erroring lines of code are from the ORM, SQLAlchemy and Python Socket being used, and this is not code we write, so it's hard at first glance to see where from our source code it's from (you must scroll to bottom of stack trace). These come from a mix of `get_products` `get_products_join` and `get_inventory` and all error on db.connect() or the sql query that's run.

One of these Issues is from BrokenPipeError. This is from deep within the sqlalchemy code so no known way to produce this locally. However I can pass bad arguments to db.connect('I cause failure') and the sql query so at least the new try/except blocks in this PR can be tested to some extent. 

When `db.connect()` and `connection.execute()` fail in production they should now surface as `DatabaseConnectionError get_products`. I'm unable to reproduce this locally, because I can pass poor arguments to `db.connect('I cause failure')` or `connection.execute('sql * bad query')` but those don't cause BrokenPipe or unpack_from errors (which will get raised as DatabaseConnectionError's).

The UnboundLocalAssignment Issue was due to poorly written code (so not a database problem) and has been fixed. 

**_More Context..._**
As the Database receives more TPS (we added 3 mobile recently) and needs to scale, we may get more of these errors. It's currently not well understood why these errors happen to begin with. You could go hunting through logs in GCP's CloudSQL logs to debug, but it's hard. I'm advised a real database layer monitoring service would be deal (and not error/performance monitoring from application layer code).

These problems happened 500 times over a 90 day period
<img width="1805" alt="image" src="https://user-images.githubusercontent.com/8920574/154780013-9210a7bf-b760-4a22-a86f-493ecded6562.png">

### Fix for New Deployment Problem.
GCP may have updated something on their side because multiple users started stackoverflow posts in the past few days on this error:
<img width="1339" alt="image" src="https://user-images.githubusercontent.com/8920574/155190058-c2983177-2be7-4c00-ae59-d78e74e9d27e.png">
and then fail to boot:
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/8920574/155190236-1967a84c-7598-420c-85c6-7710aa0a34d9.png">

https://stackoverflow.com/questions/71205205/appengine-python-502-bad-gateway-importerror-cannot-import-name-json-from
and 4 days ago
https://serverfault.com/questions/1094062/error-from-itsdangerous-import-json-as-json-importerror-cannot-import-name-j

My research findings said to...
Upgrade itsdangerous to 2.0.1 (not 2.10.0)
or
Upgrade Flask to 2.0.3

So I went with upgrading Flask because it's a Major Release upgrade and we weren't declaring a itsdangerous version in our requirements.txt.

## Solution
Let's call them all DatabaseConnectionError so it's easier to track and understand them, and catch any outliers beyond the criteria outlined above.

## Testing
Since it's hard to reproduce the errors in production, let's check things still work
[get_products](https://sentry.io/organizations/testorg-az/discover/will-flask:4a5e51453a5242ac97b3b8e4089a31d8/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=6167911&project=6112038&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) still works

[get_products_join](https://sentry.io/organizations/testorg-az/discover/will-flask:24d24c6742a94e1693931a4f0023d9cc/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=6167911&project=6112038&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) still works

[DatabaseConnectionError products](https://sentry.io/organizations/testorg-az/issues/3028836877/?project=5808655&referrer=jira_integration)
[DatabaseConnectionError products_join](https://sentry.io/organizations/testorg-az/issues/3028755889/?project=5808655&referrer=jira_integration)

[Checkout workflow events](https://sentry.io/organizations/testorg-az/performance/trace/56cd25d0b55c4f7394caa0b78bfeab52/?pageEnd=2022-02-23T06%3A10%3A46.765&pageStart=2022-02-22T06%3A10%3A46.741) all look good, upon upgrading Flask to 2.0.3
