### PR TITLE
Flask requests package and React Promise update for Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Update the app engine service name in the following places:
 // required
 react/app.yaml to staging-application-monitoring-javascript  
 react/.env to staging-application-monitoring-express, -flask, -springboot
-flask/app.yaml to staging-application-monitoring-javascript 
+flask/app.yaml to staging-application-monitoring-flask 
 express/app.yaml to staging-application-monitoring-node
 spring-boot/src/main/appengine/app.yaml to staging-springboot
 

--- a/flask/main.py
+++ b/flask/main.py
@@ -1,6 +1,7 @@
 import datetime
 import operator
 import os
+import requests
 import sys
 from flask import Flask, json, request, make_response
 from flask_cors import CORS
@@ -97,6 +98,7 @@ def products():
 
     try:
         r = requests.get(RUBY_BACKEND + "/api")
+        r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)
         
@@ -113,6 +115,7 @@ def products_join():
 
     try:
         r = requests.get(RUBY_BACKEND + "/api")
+        r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)
 
@@ -140,7 +143,7 @@ def organization():
     return "flask /organization"
 
 @app.route('/connect', methods=['GET'])
-def connect():    
+def connect():
     return "flask /connect"
 
 

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -1,5 +1,4 @@
 requests==2.27.1
-requests-toolbelt==0.9.1
 blinker==1.4
 flask==2.0.3
 flask-cors==3.0.10

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -1,3 +1,5 @@
+requests==2.27.1
+requests-toolbelt==0.9.1
 blinker==1.4
 flask==2.0.3
 flask-cors==3.0.10

--- a/react/src/components/About.js
+++ b/react/src/components/About.js
@@ -36,11 +36,15 @@ class About extends Component {
       headers: { se, customerType, email, "Content-Type": "application/json" }
     })
     
-    let response = await Promise.allSettled([request1, request2, request3])
+    // Need Safari13 in tests/config.py in order for this modern javascript to work in Safari Browser
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#browser_compatibility
+    // let response = await Promise.allSettled([request1, request2, request3])
 
+    const response = [await request1, await request2, await request3]
+    
     // Error Handling
     response.forEach(r => {
-      if (!r.value.ok) {
+      if (!r.ok) {
         Sentry.configureScope(function(scope) {
           Sentry.setContext("response", r)
         });


### PR DESCRIPTION
## Flask
I had installed `requests` it during testing to my virtual env (pyenv) but never added it to requirements.txt.


## React
Safari browsers don't have `Promise.allSettled` so using a different technique now. Need Safari13 (Selenium) in order for it to work.

`Promise.allSettled` does not throw exceptions, which is why we were advised to use it. But on second thought, we're pretty comfy using try/catch technique of throwing exceptions, rather than deal with Resolving/Rejecting promises.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled#browser_compatibility
![image](https://user-images.githubusercontent.com/8920574/155935179-1f037e47-1f26-4697-9fd7-d3230c6e8f77.png)


## Testing
Flask trace for /products + ruby /api 
https://sentry.io/organizations/testorg-az/performance/trace/134a7412942445f39c7ba1ec1ee86967/?pageEnd=2022-02-28T18%3A20%3A01.502&pageStart=2022-02-27T18%3A19%3A52.590

Page `About` on a Safari browser, no longer erroring.
https://sentry.io/organizations/testorg-az/discover/results/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5808623&query=event.type%3Aerror+title%3A%22TypeError%3A+Promise.allSettled+is+not+a+function.+%28In+%27Promise.allSettled%28%5Ba%2Cc%2Cs%5D%29%27%2C+%27Promise.allSettled%27+is+...%22&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29