### PR TITLE
Springboot http client RestTemplate

### DIFF
--- a/flask/db.py
+++ b/flask/db.py
@@ -103,7 +103,6 @@ def get_products_join():
         raise DatabaseConnectionError('get_products_join')
     except Exception as err:
         err_string = str(err)
-        print(error_string)
         if UNPACK_FROM_ERROR in err_string:
             raise DatabaseConnectionError('get_products_join')
         else:
@@ -151,7 +150,11 @@ def get_inventory(cart):
     except BrokenPipeError as err:
         raise DatabaseConnectionError('get_inventory')
     except Exception as err:
-        raise(err)
+        err_string = str(err)
+        if UNPACK_FROM_ERROR in err_string:
+            raise DatabaseConnectionError('get_inventory')
+        else:
+            raise(err)
 
     return inventory
 

--- a/flask/db.py
+++ b/flask/db.py
@@ -75,7 +75,6 @@ def get_products():
         raise DatabaseConnectionError('get_products')
     except Exception as err:
         err_string = str(err)
-        print(error_string)
         if UNPACK_FROM_ERROR in err_string:
             raise DatabaseConnectionError('get_products')
         else:

--- a/flask/db.py
+++ b/flask/db.py
@@ -74,7 +74,9 @@ def get_products():
     except BrokenPipeError as err:
         raise DatabaseConnectionError('get_products')
     except Exception as err:
-        if UNPACK_FROM_ERROR in err:
+        err_string = str(err)
+        print(error_string)
+        if UNPACK_FROM_ERROR in err_string:
             raise DatabaseConnectionError('get_products')
         else:
             raise(err)
@@ -101,7 +103,9 @@ def get_products_join():
     except BrokenPipeError as err:
         raise DatabaseConnectionError('get_products_join')
     except Exception as err:
-        if UNPACK_FROM_ERROR in err:
+        err_string = str(err)
+        print(error_string)
+        if UNPACK_FROM_ERROR in err_string:
             raise DatabaseConnectionError('get_products_join')
         else:
             raise(err)

--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -58,7 +58,7 @@ class Checkout extends Component {
     console.log('Form Submitted - state', this.state);
     console.log('Form Submitted - Cart', cart);
 
-    const transaction = Sentry.startTransaction({ name: "checkout" });
+    const transaction = Sentry.startTransaction({ name: "Submit Checkout Form" });
     // Do this or the trace won't include the backend transaction
     Sentry.configureScope(scope => scope.setSpan(transaction));
 

--- a/spring-boot/README.md
+++ b/spring-boot/README.md
@@ -2,7 +2,7 @@
 Extension to the Empower Plant UI/UX. This project was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app); this Java Spring Boot backend is available with the query param &backend=springboot, [e.g.] (http://localhost:5000/?se=simon&backend=springboot).
 
 ## Setup
-This uses java version 8.
+This uses java version 8 and SpringBoot version 2.5.4 [spring-boot-starter-parent?](https://mvnrepository.com/artifact/org.springframework.boot)
 
 1. Verify that port 8090 is set for springboot in `react/src/utils/backendrouter.js`, 
 ```
@@ -23,7 +23,7 @@ REACT_APP_SPRINGBOOT_BACKEND=<value>
 
 5. Put your DSN key in application.properties
 
-### Local DEV deployment
+### Run
 Verify that the **DEV** section is not commented out in application.properties and values are set. The **GCP** section should be commented out.
 ```
 spring.datasource.url=jdbc:postgresql://<server>:<port>/<database name>
@@ -31,7 +31,7 @@ server.port=8090
 spring.cloud.gcp.sql.enabled=false
 ```
 
-Run from terminal with `./mvnw spring-boot:run` from the spring-boot directory
+Run `./run.sh`
 
 ### Cloud GCP Deployment
 Verify that the **GCP** section is not commented AND **DEV** section is commented (i.e. `application.properties` should have no values for `spring.datasource.url` nor `server.port`).

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -22,13 +22,13 @@
 		<dependency>
     		<groupId>io.sentry</groupId>
     		<artifactId>sentry-spring-boot-starter</artifactId>
-    		<version>5.5.2</version>
+    		<version>5.6.1</version>
 		</dependency>
 		<!-- Sentry Logback SDK -->
 		<dependency>
 		    <groupId>io.sentry</groupId>
 		    <artifactId>sentry-logback</artifactId>
-		    <version>5.5.2</version>
+		    <version>5.6.1</version>
 		</dependency>
 		<!-- Capture Sentry Transaction -->
 		<dependency>

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
@@ -156,15 +156,12 @@ public class AppController {
 	@CrossOrigin
 	@GetMapping("/products")
 	public String GetProductsDelay(HttpServletRequest request) {
-		setTags(request);
 
-		logger.info("> products...");
+		logger.info("> products calling ruby");
 		String fooResourceUrl = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";
 		ResponseEntity<String> response = restTemplate.getForEntity(fooResourceUrl + "/api", String.class);
 
-		ISpan span = hub.getSpan().startChild("Overhead", "Set tags");
-		setTags(request);
-		span.finish();
+		logger.info("> products calling db for products");
 		String allProducts = dbHelper.mapAllProducts(hub.getSpan());
 		return allProducts;
 	}

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -30,11 +31,14 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.web.client.RestTemplate;
+
 @RestController
 public class AppController {
 
 	private final Logger logger = LoggerFactory.getLogger(Application.class);
 	private List<String> headerTags = new ArrayList<>();
+	private RestTemplate restTemplate = new RestTemplate();
 	
 	@Autowired
 	private DatabaseHelper dbHelper = new DatabaseHelper();
@@ -52,7 +56,6 @@ public class AppController {
 	}
 
 	private void setTags(HttpServletRequest request) {
-		//to print all headers
 		/*
 		 * logger.info("request header names and vals: "); for (Enumeration<?> e =
 		 * request.getHeaderNames(); e.hasMoreElements();) { String nextHeaderName =
@@ -88,8 +91,9 @@ public class AppController {
 
 	@CrossOrigin
 	@GetMapping("/success")
-	public String Success() {
+	public String Success(HttpServletRequest request) {
 		logger.info("success");
+		setTags(request);
 		return "success from springboot";
 
 	}
@@ -116,19 +120,27 @@ public class AppController {
 
 	@CrossOrigin
 	@GetMapping("/api")
-	public String Api() {
+	public String Api(HttpServletRequest request) {
+		logger.info("> /api");
+		setTags(request);
+
+		String RUBY_BACKEND = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";
+		ResponseEntity<String> response = restTemplate.getForEntity(RUBY_BACKEND + "/api", String.class);
+
 		return "springboot /api";
 	}
 
 	@CrossOrigin
 	@GetMapping("/connect")
-	public String Connect() {
+	public String Connect(HttpServletRequest request) {
+		setTags(request);
 		return "springboot /connect";
 	}
 
 	@CrossOrigin
 	@GetMapping("/organization")
-	public String Organization() {
+	public String Organization(HttpServletRequest request) {
+		setTags(request);
 		return "springboot /organization";
 	}
 
@@ -146,12 +158,17 @@ public class AppController {
 	@CrossOrigin
 	@GetMapping("/products")
 	public String GetProductsDelay(HttpServletRequest request) {
+		setTags(request);
+
+		logger.info("> products");
+		String fooResourceUrl = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";
+		ResponseEntity<String> response = restTemplate.getForEntity(fooResourceUrl + "/api", String.class);
+		// return "/products success";
+
 		ISpan span = hub.getSpan().startChild("Overhead", "Set tags");
-		//initInventory(); // initialize inventory each time we hit this endpoint
 		setTags(request);
 		span.finish();
 		String allProducts = dbHelper.mapAllProducts(hub.getSpan());
-		
 		return allProducts;
 	}
 

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
@@ -65,10 +65,8 @@ public class AppController {
 		 */
 
 		for (String tag : headerTags) {
-			logger.info("Checking header for tag: " + tag);
 			String header = request.getHeader(tag);
 			if (header != null && header != "null") {
-				logger.info("Setting " + tag + " Sentry tag as " + header);
 				if (tag == "email") {
 					User user = new User();
 					user.setEmail(header);
@@ -160,10 +158,9 @@ public class AppController {
 	public String GetProductsDelay(HttpServletRequest request) {
 		setTags(request);
 
-		logger.info("> products");
+		logger.info("> products...");
 		String fooResourceUrl = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";
 		ResponseEntity<String> response = restTemplate.getForEntity(fooResourceUrl + "/api", String.class);
-		// return "/products success";
 
 		ISpan span = hub.getSpan().startChild("Overhead", "Set tags");
 		setTags(request);

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
@@ -156,10 +156,10 @@ public class AppController {
 	@CrossOrigin
 	@GetMapping("/products")
 	public String GetProductsDelay(HttpServletRequest request) {
-
-		logger.info("> products calling ruby");
-		String fooResourceUrl = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";
-		ResponseEntity<String> response = restTemplate.getForEntity(fooResourceUrl + "/api", String.class);
+		// UPDATE 03/09/22 commenting this ruby call out only because I have to merge the PR. Currently the ruby transaction this creates, becomes orphaned. It is not part of the trace with the Javascript<>Springboot /products endpoint Tracing here
+		// logger.info("> products calling ruby");
+		// String fooResourceUrl = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";
+		// ResponseEntity<String> response = restTemplate.getForEntity(fooResourceUrl + "/api", String.class);
 
 		logger.info("> products calling db for products");
 		String allProducts = dbHelper.mapAllProducts(hub.getSpan());

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/AppController.java
@@ -156,6 +156,8 @@ public class AppController {
 	@CrossOrigin
 	@GetMapping("/products")
 	public String GetProductsDelay(HttpServletRequest request) {
+		setTags(request);
+		
 		// UPDATE 03/09/22 commenting this ruby call out only because I have to merge the PR. Currently the ruby transaction this creates, becomes orphaned. It is not part of the trace with the Javascript<>Springboot /products endpoint Tracing here
 		// logger.info("> products calling ruby");
 		// String fooResourceUrl = "https://application-monitoring-ruby-dot-sales-engineering-sf.appspot.com";

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Bean;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
 
 import io.sentry.Sentry;
 

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
@@ -5,7 +5,10 @@ import java.sql.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Bean;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
 
 import io.sentry.Sentry;
 
@@ -54,6 +57,11 @@ public class Application {
 					}
 				});
 		});
+	}
+
+	@Bean
+	RestTemplate restTemplate(RestTemplateBuilder builder) {
+		return builder.build();
 	}
 
 	@SuppressWarnings("deprecation")

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
@@ -43,17 +43,18 @@ public class Application {
 	@Override
 		public Double sample(SamplingContext context) {
 			// logger.info("> testing...."); // works
-			// logger.info("> context is", context); // is blank
-			// logger.info("> context is", "test..."); // is blank
+			// logger.info("> context is", context); // context is blank
+			// logger.info("> context is", "test..."); // "text..." does not appear, it logs blank
 			
 			CustomSamplingContext customSamplingContext = context.getCustomSamplingContext();
 			if (customSamplingContext != null) {
 				HttpServletRequest request = (HttpServletRequest) customSamplingContext.get("request");
 
+				// TODO - fix this. The event does not get captured (it's dropped?) if you add this Context here (is it too big?)
 				// trying to find what on the request indicates it's an OPTIONS request, because we want to filter those out
-				Sentry.configureScope(scope -> {
-					scope.setContexts("> customSamplingContext...", request);
-				});
+				// Sentry.configureScope(scope -> {
+				// 	scope.setContexts("> customSamplingContext...", request);
+				// });
 				
 				// this header only appears on OPTIONS requests, so could filter out OPTIONS this way
 				// but it is not logging a value here, though is visible on the transaction event in Sentry.io

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
@@ -33,33 +33,6 @@ public class Application {
 		SpringApplication.run(Application.class, args);
 	}
 
-	// sentry properties configured here for Java Spring Boot
-	// https://docs.sentry.io/platforms/java/guides/spring-boot/logging-frameworks/	
-	@Bean
-	public void initSentry() {
-		logger.info("Initializing Sentry...");
-		
-		Sentry.init(options -> {
-			options.setDsn(sentryDSN);
-			String environment = ((System.getenv("SPRINGBOOT_ENV") == null ? springbootlocalenv : System.getenv("SPRINGBOOT_ENV")));
-			options.setEnvironment(environment);
-			options.setTracesSampleRate(1.0);
-			options.setRelease(getRelease());
-			
-			options.setTracesSampler(
-				context -> {
-					//context.getTransactionContext().getName() returns String: GET /products
-					if (context.getTransactionContext().getOperation().equals("http.server") &&
-							context.getTransactionContext().getName().startsWith("OPTIONS")) {
-						//Not sampling OPTIONS transactions
-						return 0.0;
-					} else {
-						return 1.0;
-					}
-				});
-		});
-	}
-
 	@Bean
 	RestTemplate restTemplate(RestTemplateBuilder builder) {
 		return builder.build();

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
@@ -43,20 +43,21 @@ public class Application {
 	@Override
 		public Double sample(SamplingContext context) {
 			// logger.info("> testing...."); // works
-			// logger.info("> context is", context); // blank
-			// logger.info("> context is", "test..."); // blank
+			// logger.info("> context is", context); // is blank
+			// logger.info("> context is", "test..."); // is blank
 			
 			CustomSamplingContext customSamplingContext = context.getCustomSamplingContext();
 			if (customSamplingContext != null) {
 				HttpServletRequest request = (HttpServletRequest) customSamplingContext.get("request");
 
-				// TODO
-				// Sentry.configureScope(scope -> {
-				// 	scope.setContexts("> customSamplingContext...", request);
-				// });
+				// trying to find what on the request indicates it's an OPTIONS request, because we want to filter those out
+				Sentry.configureScope(scope -> {
+					scope.setContexts("> customSamplingContext...", request);
+				});
+				
+				// this header only appears on OPTIONS requests, so could filter out OPTIONS this way
+				// but it is not logging a value here, though is visible on the transaction event in Sentry.io
 				// logger.info("> Access-Control-Request-Method...", request.getHeader("Access-Control-Request-Method"));
-				// logger.info("> request.something", request.getName());
-
 				return 1.0;
 			} else {
 				return 1.0;

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/Application.java
@@ -42,23 +42,10 @@ public class Application {
 	class CustomTracesSamplerCallback implements TracesSamplerCallback {
 	@Override
 		public Double sample(SamplingContext context) {
-			// logger.info("> testing...."); // works
-			// logger.info("> context is", context); // context is blank
-			// logger.info("> context is", "test..."); // "text..." does not appear, it logs blank
-			
+
 			CustomSamplingContext customSamplingContext = context.getCustomSamplingContext();
 			if (customSamplingContext != null) {
 				HttpServletRequest request = (HttpServletRequest) customSamplingContext.get("request");
-
-				// TODO - fix this. The event does not get captured (it's dropped?) if you add this Context here (is it too big?)
-				// trying to find what on the request indicates it's an OPTIONS request, because we want to filter those out
-				// Sentry.configureScope(scope -> {
-				// 	scope.setContexts("> customSamplingContext...", request);
-				// });
-				
-				// this header only appears on OPTIONS requests, so could filter out OPTIONS this way
-				// but it is not logging a value here, though is visible on the transaction event in Sentry.io
-				// logger.info("> Access-Control-Request-Method...", request.getHeader("Access-Control-Request-Method"));
 				return 1.0;
 			} else {
 				return 1.0;

--- a/spring-boot/src/main/java/com/sentrydemos/springboot/DatabaseHelper.java
+++ b/spring-boot/src/main/java/com/sentrydemos/springboot/DatabaseHelper.java
@@ -29,7 +29,6 @@ public class DatabaseHelper {
 	
 	
 	public String mapAllProducts(ISpan span) {
-		logger.info("mapAllProducts");
 
 		String sql = "SELECT * FROM products";
 		ISpan sqlSpan = span.startChild("db", sql);
@@ -66,7 +65,6 @@ public class DatabaseHelper {
 	}
 
 	public String mapAllProductsJoin(ISpan transaction) {
-		logger.info("mapAllProductsJoin");
 		
 		String sql = "SELECT * FROM products";
 		ISpan sqlSpan = transaction.startChild("db", sql);

--- a/spring-boot/src/main/resources/application.properties.example
+++ b/spring-boot/src/main/resources/application.properties.example
@@ -22,8 +22,6 @@ sentry.exception-resolver-order=-1
 sentry.enable-tracing=true
 sentry.traces-sample-rate=1.0
 
-SPRINGBOOT_LOCAL_ENV=test
-
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.username=
 spring.datasource.password=


### PR DESCRIPTION
## Overview
- **Springboot** - Upgraded sentry springboot sdk to 5.6.1
- **React** - renamed custom checkout transaction to 'Submit Checkout Form' which is what our react native demo app does now.
- **Flask** - fixed db error handling problem

HttpRestTemplate has been implemented in Springboot for making http requests.

Springboot **will soon** make http requests to Ruby. Currently the Ruby transaction gets made but is orphaned, it's not part of the trace with Javascript+Springboot, and so I commented out the ruby /api call in the springboot /products endpoint.

## Testing
Springboot [transaction](https://sentry.io/organizations/testorg-az/discover/results/?field=title&field=event.type&field=transaction.op&field=project&field=sdk.version&field=timestamp&name=All+Events&project=6090082&query=url%3A%22http%3A%2F%2Flocalhost%3A%2A%22&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) with 5.6.1

[Submit Checkout Form](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:a1d0a7ff2d70464abbc1e418d81fc278/?field=title&field=event.type&field=transaction.op&field=project&field=user.display&field=timestamp&name=All+Events&query=se%3Awill&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) transaction

The python error can only be replicated in prod.