### PR TITLE
Parameterize Transactions with beforeNavigate

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ source env/bin/activate
 Add +2 quantity of a single item to Cart and purchase in order to trigger an Error. Visit all routes defined in src/index.js to produce transactions for them.
 
 
-## Deploy
+## Deploy to Prod
 This script deploys the flagship apps React + Flask. For deploying a single app to App Engine, check each platform's README for specific instructions. Make sure all .env's and app.yaml's have correct values before deploying.
 ```
 ./deploy.sh
@@ -88,10 +88,7 @@ deploy.sh's SENTRY_PROJECT with updated value
 ```
 Then run deploy.sh for deploying the flagship app (React to Flask) together, or deploy only the individual apps that you need (check the README for each platform). 
 
-## Troubleshooting
-Did you remember to permit / whitelist your IP address as an 'Authorized Network' in CloudSQL?
-
-### Upgrading
+## Updating The Apps
 ```
 ## Check if you're on your fork. If so, you should see:
 git remote -v
@@ -120,12 +117,11 @@ cd flask && source env/bin/activate && pip install -r requirements.txt
 
 # Check that your react/.env, flask/.env and deploy.sh still have correct values
 ```
-### Releases
-Q. `--update-env-vars` is not available for `gcloud app deploy`, therefore can't pass a RELEASE upon deploying. Luckily it's already built into the /build which gets uploaded, and sentry-cli generated it, as well as the RELEASE that sentry-cli uses for uploading source maps.
 
-A. So, creating the dynamic Release inside of main.py. Hard-coding it into .env wouldn't help, as it needs to be dynamic. This release may not match what sentry-cli is generating for release (due to clock skew), but we're not uploading source maps for python. Worst case, the Python release is slightly different than the React release, but this shouldn't matter, because two separate apps (repo) typically have unique app version numbers anyways (you version them separately).
+## Troubleshooting
+See [troubleshooting](./troubleshooting.md)
 
-### Gcloud commands
+## Gcloud
 ```
 gcloud app versions list
 gcloud app deploy
@@ -142,9 +138,9 @@ gcloud auth list
 gcloud config set account `ACCOUNT`
 gcloud config list, to display current account
 ```
+`gcloud app deploy` does not support `--update-env-vars RELEASE=$RELEASE` like `gcloud run deploy` does with Cloud Run
 
-### Other
-Don't use a sqlalchemy or pg8000 that is higher than sqlalchemy==1.3.15, pg8000==1.12.5, or else database won't work.
+## Versions
 
 | non-sentry    | version
 | ------------- |:-------------:|
@@ -157,22 +153,3 @@ Don't use a sqlalchemy or pg8000 that is higher than sqlalchemy==1.3.15, pg8000=
 | react-router-dom | ^5.2.0 |
 | react-scripts | 4.0.3 |
 
-'default' is a function applied to objects that aren't serializable.  
-use 'default' or else you get "Object of type datetime is not JSON serializable":  
-json.dumps(results, default=str)  
-
-`gcloud app deploy` does not support `--update-env-vars RELEASE=$RELEASE` like `gcloud run deploy` does with Cloud Run
-
-https://dev.to/brad_beggs/handling-react-form-submit-with-redirect-async-await-for-the-beyond-beginner-57of
-
-https://www.pluralsight.com/guides/how-to-transition-to-another-route-on-successful-async-redux-action
-
-https://reactjs.org/docs/forms.html
-
-State Hooks vs Effect Hooks vs Context
-https://reactjs.org/docs/hooks-state.html
-
-Context
-https://reactjs.org/docs/hooks-effect.html
-
-https://docs.sentry.io/platforms/python/guides/flask/configuration/filtering/#using-sampling-to-filter-transaction-events

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ deploy.sh's SENTRY_PROJECT with updated value
 Then run deploy.sh for deploying the flagship app (React to Flask) together, or deploy only the individual apps that you need (check the README for each platform). 
 
 ## Troubleshooting
+Did you remember to permit / whitelist your IP address as an 'Authorized Network' in CloudSQL?
+
 ### Upgrading
 ```
 ## Check if you're on your fork. If so, you should see:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ source env/bin/activate
 ./run.sh
 ```
 
-Add +2 quantity of a single item to Cart and purchase in order to trigger an Error. Visit all routes defined in src/index.js to produce transactions for them.
+Add +2 quantity of a single item to Cart and purchase in order to trigger an Error. Visit the routes defined in src/index.js to produce transactions.
 
 
 ## Deploy to Prod

--- a/react/src/components/Employee.js
+++ b/react/src/components/Employee.js
@@ -13,8 +13,8 @@ class Employee extends Component {
 
   async componentDidMount() {
     const { match } = this.props;
-    if (match.params.slug) {
-      const data = await import(`./employees/${match.params.slug}`);
+    if (match.params.id) {
+      const data = await import(`./employees/${match.params.id}`);
       this.setState({ employee: data.default });
     }
   }

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -60,6 +60,13 @@ Sentry.init({
       _metricOptions: {
         _reportAllChanges: true,
       },
+      // How to parameterize transactions if not using the <SentryRoute> component
+      // beforeNavigate: context => {
+      //   return {
+      //     ...context,
+      //     name: window.location.pathname.replace(/\/employee.*/,'/employee/:id')
+      //   };
+      // },
     }),
   ],
   tracesSampleRate: 1.0,

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -53,6 +53,9 @@ console.log("RELEASE", RELEASE)
 
 Sentry.init({
   dsn: DSN,
+  release: RELEASE,
+  environment: ENVIRONMENT,
+  tracesSampleRate: 1.0,
   integrations: [
     new Integrations.BrowserTracing({
       tracingOrigins: tracingOrigins,
@@ -60,18 +63,14 @@ Sentry.init({
       _metricOptions: {
         _reportAllChanges: true,
       },
-      // How to parameterize transactions if not using the <SentryRoute> component
-      // beforeNavigate: context => {
-      //   return {
-      //     ...context,
-      //     name: window.location.pathname.replace(/\/employee.*/,'/employee/:id')
-      //   };
-      // },
+      beforeNavigate: context => {
+        return {
+          ...context,
+          name: window.location.pathname.replace(/\/employee.*/,'/employee/:id')
+        };
+      },
     }),
   ],
-  tracesSampleRate: 1.0,
-  release: RELEASE,
-  environment: ENVIRONMENT,
   beforeSend(event, hint) {
     // Parse from tags because src/index.js already set it there. Once there are React route changes, it is no longer in the URL bar
     let se
@@ -166,7 +165,9 @@ class App extends Component {
                 <Route path="/complete" component={Complete} />
                 <Route path="/error" component={CompleteError} />
                 <Route path="/cra" component={Cra} />
-                <SentryRoute path="/employee/:slug" component={Employee}></SentryRoute>
+                {/* Parameterization of the Employee Pages is done by beforeNavigate  */}
+                <Route path="/employee/:id" component={Employee} />
+                {/* Parameterizes the Product Page transactions */}
                 <SentryRoute path="/product/:id" component={Product}></SentryRoute>
                 <Route path="/products">
                   <Products backend={BACKEND_URL} />

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,43 @@
+# Troubleshooting
+Troubleshooting steps and knowledge for different parts of the software and Sentry
+
+## Database problems
+Don't use a sqlalchemy or pg8000 that is higher than sqlalchemy==1.3.15, pg8000==1.12.5, or things will fail.
+
+If you're running the app locally and the database queries are failing, here are some things to check:
+
+Did you remember to permit / whitelist your IP address as an 'Authorized Network' in CloudSQL?
+
+Did any of the Connection Info for the CloudSQL instance change? Go to  CLoudSQL Settings -> Connection Info and check HOST and other details from the .env files.
+
+Did the GCP documentation change? For connecting via Unix socket vs TCP, regarding the recommended libraries and implementations to use.
+
+When was this last run successfully? Check past closed PR's.
+
+Did you try all of the interchangeable backends Python, Java, Node? Or is only 1 of them failing?
+
+## Releases
+Q. `--update-env-vars` is not available for `gcloud app deploy`, therefore can't pass a RELEASE upon deploying. Luckily it's already built into the /build which gets uploaded, and sentry-cli generated it, as well as the RELEASE that sentry-cli uses for uploading source maps.
+
+A. So, creating the dynamic Release inside of main.py. Hard-coding it into .env wouldn't help, as it needs to be dynamic. This release may not match what sentry-cli is generating for release (due to clock skew), but we're not uploading source maps for python. Worst case, the Python release is slightly different than the React release, but this shouldn't matter, because two separate apps (repo) typically have unique app version numbers anyways (you version them separately).
+
+## Python
+'default' is a function applied to objects that aren't serializable.  
+use 'default' or else you get "Object of type datetime is not JSON serializable":  
+json.dumps(results, default=str)  
+
+
+## React
+https://dev.to/brad_beggs/handling-react-form-submit-with-redirect-async-await-for-the-beyond-beginner-57of
+
+https://www.pluralsight.com/guides/how-to-transition-to-another-route-on-successful-async-redux-action
+
+https://reactjs.org/docs/forms.html
+
+State Hooks vs Effect Hooks vs Context
+https://reactjs.org/docs/hooks-state.html
+
+Context
+https://reactjs.org/docs/hooks-effect.html
+
+https://docs.sentry.io/platforms/python/guides/flask/configuration/filtering/#using-sampling-to-filter-transaction-events


### PR DESCRIPTION
## Overview
Parameterized transaction names ([docs](https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#parameterized-transaction-names)) are useful to consolidate transactions (ex. `/teams/:teamid/user/:userid` instead of `/teams/123/user/345`).

This was tested successfully.

`beforeNavigate` is now used for parameterizing the Employee Page transactions, as `/employee/:id`


`<SentryRoute>` is _still_ used for parameterizing the Product Page transactions, as `/product/:id`

Using both, so we have an example of both, ready in our codebase at all times, for learning from, and experimenting, and debugging customer problems.

## Testing1
Showing 'before' so you can confirm the quality of the transactions is unharmed. I could not find significant differences between the two.

#### with \<SentryRoute\>
[/employee/:id](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:75f8a91710b04a259d09462d4276c56f/?field=title&field=event.type&field=project&field=url&field=timestamp&name=All+Events&project=5808623&query=url%3A%22http%3A%2F%2Flocalhost%3A%2A%22&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

#### with beforeNavigate
[/employee/:id](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:0016a9b05fa745cd96194bff0a490dd6/?field=title&field=event.type&field=project&field=url&field=timestamp&name=All+Events&project=5808623&query=url%3A%22http%3A%2F%2Flocalhost%3A%2A%22&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)

[/employee/:id PROD](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:32a8f2a253154a87af01e8dd4dd12e8c/?field=project&field=event.type&field=title&field=se&field=sdk.version&field=sdk.name&field=release&field=timestamp&id=10489&name=Application+Monitoring+Web&project=5808623&query=%21se%3Areplay+event.type%3Atransaction+title%3A%22%2Femployee%2F%3Aid%22&sort=-timestamp&statsPeriod=1h&topEvents=5&widths=-1&widths=-1&widths=205&yAxis=count%28%29)

## Testing2
Before vs After
![image](https://user-images.githubusercontent.com/8920574/164487483-2aa9a208-5752-48d4-a048-6e6549a9367a.png)

#### using no parameterization, each employee page is a transaction
[/employee/keith](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:d9b8345069fa481ca5ca151a46126126/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5808623&query=http.url%3A%22http%3A%2F%2Flocalhost%3A3000%2A%22+title%3A%22%2Femployee%2A%22&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
[/employee/lily](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:a137d8be33d3484ea86afc15e2ceb07f/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5808623&query=http.url%3A%22http%3A%2F%2Flocalhost%3A3000%2A%22+title%3A%22%2Femployee%2A%22&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
#### using parameterization, employee pages are consolidated to one transaction 
[/employee/:id](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:e15c58442c294533ab717e4e264f1f5b/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5808623&query=http.url%3A%22http%3A%2F%2Flocalhost%3A3000%2A%22+title%3A%22%2Femployee%2A%22&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29)
