### PR TITLE
Updated RELEASE val with package

### DIFF
--- a/react/run.sh
+++ b/react/run.sh
@@ -1,6 +1,7 @@
 # Builds and serves the js bundle, uploads sourcemaps and does suspect commits
-
-RELEASE=`../release.sh`
+PACKAGE="application.monitoring.javascript"
+VERSION=`../release.sh`
+RELEASE=$PACKAGE@$VERSION
 echo $RELEASE
 
 SENTRY_ORG=testorg-az

--- a/react/run.sh
+++ b/react/run.sh
@@ -1,6 +1,6 @@
 # Builds and serves the js bundle, uploads sourcemaps and does suspect commits
 
-PACKAGE="application.monitoring.javascript"
+PACKAGE=application.monitoring.javascript
 VERSION=`../release.sh`
 RELEASE=$PACKAGE@$VERSION
 echo $RELEASE

--- a/react/run.sh
+++ b/react/run.sh
@@ -1,4 +1,5 @@
 # Builds and serves the js bundle, uploads sourcemaps and does suspect commits
+
 PACKAGE="application.monitoring.javascript"
 VERSION=`../release.sh`
 RELEASE=$PACKAGE@$VERSION


### PR DESCRIPTION
 - [x] Bugfix
 - [ ] New feature
 - [ ] Enhancement
 - [ ] Refactoring

### Description
Local Empower Plant frontend source maps are not getting used which manifested in error `Cannot fetch resource due to restricted IP address`

The change is updating ./run.sh to use package name as a part of `RELEASE`; [matching react/src/index.js](https://github.com/sentry-demos/application-monitoring/blob/master/react/src/index.js#L49).

### Before
Before this change, [an Issue event's source maps are not applied](https://sentry.io/organizations/testorg-az/issues/3261093431/events/a5320aee02364a03bd1d5d09d7347b53/?project=5952962) and multiple releases are created (e.g. application.monitoring.javascript@2.2.2 and 2.2.2).
<img width="784" alt="image" src="https://user-images.githubusercontent.com/89550162/167517528-53bed626-9ba6-46aa-905d-7b970b6738fa.png">

### After
By applying this change, [source maps are applied as expected](https://sentry.io/organizations/testorg-az/issues/3261078026/events/533ff2f1ba714afab514e7947a48ffe3/?project=5952962) and the single correct release is created (e.g. application.monitoring.javascript@2.2.3).
<img width="769" alt="image" src="https://user-images.githubusercontent.com/89550162/167517570-5ba85fab-38e4-43a0-8ef1-12b81e0ddc37.png">

