### PR TITLE
Fix: Read headers in ruby

### DIFF
--- a/flask/main.py
+++ b/flask/main.py
@@ -7,7 +7,7 @@ from flask import Flask, json, request, make_response
 from flask_cors import CORS
 from dotenv import load_dotenv
 from db import get_products, get_products_join, get_inventory
-from utils import release, wait
+from utils import release, wait, parseHeaders
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -17,6 +17,7 @@ RELEASE = os.environ.get("RELEASE") or release()
 DSN = os.getenv("FLASK_APP_DSN")
 ENVIRONMENT = os.environ.get("FLASK_ENV") or "production"
 RUBY_BACKEND = os.environ.get("RUBY_BACKEND")
+RUBY_CUSTOM_HEADERS = ['se', 'customerType', 'email']
 
 print("> DSN", DSN)
 print("> RELEASE", RELEASE)
@@ -97,11 +98,7 @@ def products():
         raise(err)
 
     try:
-        headers = {
-            "se" : None if request.headers.get('Se') == 'undefined' else request.headers.get('Se'),
-            "customerType" : None if request.headers.get('Customertype') == 'undefined' else request.headers.get('Customertype'),
-            "email" : None if request.headers.get('Email') == 'undefined' else request.headers.get('Email')
-        }
+        headers = parseHeaders(RUBY_CUSTOM_HEADERS, request.headers)
         r = requests.get(RUBY_BACKEND + "/api", headers=headers)
         r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
@@ -119,11 +116,7 @@ def products_join():
         raise(err)
 
     try:
-        headers = {
-            "se" : None if request.headers.get('Se') == 'undefined' else request.headers.get('Se'),
-            "customerType" : None if request.headers.get('Customertype') == 'undefined' else request.headers.get('Customertype'),
-            "email" : None if request.headers.get('Email') == 'undefined' else request.headers.get('Email')
-        }
+        headers = parseHeaders(RUBY_CUSTOM_HEADERS, request.headers)
         r = requests.get(RUBY_BACKEND + "/api", headers=headers)
         r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:

--- a/flask/main.py
+++ b/flask/main.py
@@ -88,7 +88,7 @@ def success():
     return "success from flask"
 
 @app.route('/products', methods=['GET'])
-def products():    
+def products():   
     try:
         with sentry_sdk.start_span(op="/products.get_products", description="function"):
             rows = get_products()
@@ -97,7 +97,12 @@ def products():
         raise(err)
 
     try:
-        r = requests.get(RUBY_BACKEND + "/api", headers=request.headers)
+        headers = {
+            "se" : None if request.headers.get('Se') == 'undefined' else request.headers.get('Se'),
+            "customerType" : None if request.headers.get('Customertype') == 'undefined' else request.headers.get('Customertype'),
+            "email" : None if request.headers.get('Email') == 'undefined' else request.headers.get('Email')
+        }
+        r = requests.get(RUBY_BACKEND + "/api", headers=headers)
         r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)
@@ -114,7 +119,12 @@ def products_join():
         raise(err)
 
     try:
-        r = requests.get(RUBY_BACKEND + "/api", headers=request.headers)
+        headers = {
+            "se" : None if request.headers.get('Se') == 'undefined' else request.headers.get('Se'),
+            "customerType" : None if request.headers.get('Customertype') == 'undefined' else request.headers.get('Customertype'),
+            "email" : None if request.headers.get('Email') == 'undefined' else request.headers.get('Email')
+        }
+        r = requests.get(RUBY_BACKEND + "/api", headers=headers)
         r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/flask/main.py
+++ b/flask/main.py
@@ -97,7 +97,7 @@ def products():
         raise(err)
 
     try:
-        r = requests.get(RUBY_BACKEND + "/api")
+        r = requests.get(RUBY_BACKEND + "/api", headers=request.headers)
         r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)
@@ -105,7 +105,7 @@ def products():
     return rows
 
 @app.route('/products-join', methods=['GET'])
-def products_join():    
+def products_join():  
     try:
         with sentry_sdk.start_span(op="/products-join.get_products_join", description="function"):
             rows = get_products_join()
@@ -114,7 +114,7 @@ def products_join():
         raise(err)
 
     try:
-        r = requests.get(RUBY_BACKEND + "/api")
+        r = requests.get(RUBY_BACKEND + "/api", headers=request.headers)
         r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/flask/main.py
+++ b/flask/main.py
@@ -105,7 +105,7 @@ def products():
     return rows
 
 @app.route('/products-join', methods=['GET'])
-def products_join():  
+def products_join():
     try:
         with sentry_sdk.start_span(op="/products-join.get_products_join", description="function"):
             rows = get_products_join()

--- a/flask/utils.py
+++ b/flask/utils.py
@@ -32,3 +32,10 @@ def weighter(condition, hour):
     current_hour = datetime.now(timezone('America/Los_Angeles')).hour
     time_to_sleep = choices(times, weights1) if condition(current_hour, hour)  else choices(times, weights2)
     return time_to_sleep[0]
+
+def parseHeaders(keys, headers):
+    parsedHeaders = {}
+    for key in keys:
+        value = headers.get(key) if headers.get(key) != "undefined" else None
+        parsedHeaders[key] = value
+    return parsedHeaders

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -20,11 +20,22 @@ set :allow_headers, "content-type,if-modified-since,accept,access-control-reques
 # This is for Auto Instrumenting the transaction
 use Sentry::Rack::CaptureExceptions
 
-# Parse Request Headers for setting customerType, se, backendType. not working
-# https://github.com/sinatra/sinatra#rack-middleware
-# before do
-#   print "before"
-# end
+before do
+  se = request.env["HTTP_SE"]
+  if !se.nil?
+    Sentry.set_tags("se": se)
+  end
+
+  customerType = request.env["HTTP_CUSTOMERTYPE"]
+  if !customerType.nil?
+    Sentry.set_tags("customerType": customerType)
+  end
+
+  email = request.env["HTTP_EMAIL"]
+  if !email.nil?
+    Sentry.set_tags("email": email)
+  end
+end
 
 get "/" do
   "Sentry Ruby Service says Hello - turn me into a microservice that powers Invoicing, Trucking, or DriverFind"


### PR DESCRIPTION
Type of Change:

- [x]  Bugfix
- [ ]  New feature
- [ ]  Enhancement
- [ ]  Refactoring

Summary:

Ruby backend was not parsing the headers sent, so it was missing information like the `se`, `customerType` and `email` tags. Since the flask backend is also making a call to the ruby backend, I added the headers there as well.

Transactions

[link](https://sentry.io/share/issue/c019bc3c7fa6423f95e2ca699a5dcfac/)

