### PR TITLE
Ruby Traces Sampler Filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ flask/.virtualenv
 flask/envtest
 node/node_modules
 node/package-lock.json
-ruby/Gemfile.lock
+
 flask/test.py
 react/app.yaml
 flask/app.yaml

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.2.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    rspec_junit_formatter (0.5.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    ruby2_keywords (0.0.5)
+    sentry-ruby (5.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    sinatra (2.2.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
+      tilt (~> 2.0)
+    sinatra-cors (1.2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack-test
+  rspec
+  rspec_junit_formatter
+  sentry-ruby
+  sinatra
+  sinatra-cors
+
+BUNDLED WITH
+   1.17.2

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -35,3 +35,9 @@ If you get an error about invalid authentication credentials, try running this f
 ```
 gcloud auth login
 ```
+
+
+## Upgrade Pathway
+update version in Gemfile.lock  
+bundle update sentry-ruby  
+bundle update sentry-ruby-core  

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -7,7 +7,6 @@ Sentry.init do |config|
   config.traces_sampler = lambda do |sampling_context|
 
     request_method = sampling_context[:env]["REQUEST_METHOD"]
-    puts request_method
     if request_method == "OPTIONS"
       return 0.0
     end

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -5,21 +5,15 @@ Sentry.init do |config|
   config.release = "22.8.2"
   config.traces_sample_rate = 1.0
   config.traces_sampler = lambda do |sampling_context|
-    puts ">>>>>>>>>>>"
 
-    env = sampling_context[:env]
-
-    # prints env, and you can see "REQUEST_METHOD"=>"GET" on it
-    # puts env
-
-    request_method = env["REQUEST_METHOD"]
-
-    # prints blank, "", nothing
-    puts request_method 
+    request_method = sampling_context[:env]["REQUEST_METHOD"]
+    puts request_method
+    if request_method == "OPTIONS"
+      return 0.0
+    end
 
     transaction_context = sampling_context[:transaction_context]
     transaction_name = transaction_context[:name]
-
     if transaction_name == "/favicon.ico"
       return 0.0
     end

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -5,8 +5,17 @@ Sentry.init do |config|
   config.release = "22.8.2"
   config.traces_sample_rate = 1.0
   config.traces_sampler = lambda do |sampling_context|
-    
-    puts sampling_context
+    puts ">>>>>>>>>>>"
+
+    env = sampling_context[:env]
+
+    # prints env, and you can see "REQUEST_METHOD"=>"GET" on it
+    # puts env
+
+    request_method = env[:REQUEST_METHOD]
+
+    # prints blank, "", nothing
+    puts request_method 
 
     transaction_context = sampling_context[:transaction_context]
     transaction_name = transaction_context[:name]

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -2,10 +2,20 @@ require 'sentry-ruby'
 
 Sentry.init do |config|
   config.dsn = 'https://21ebb52573ba4e999e4a49277b45daac@o87286.ingest.sentry.io/6231039'
-  config.release = "2.3"
+  config.release = "22.8.2"
   config.traces_sample_rate = 1.0
   config.traces_sampler = lambda do |sampling_context|
-    true # can also return a float between 0.0 and 1.0
+    
+    puts sampling_context
+
+    transaction_context = sampling_context[:transaction_context]
+    transaction_name = transaction_context[:name]
+
+    if transaction_name == "/favicon.ico"
+      return 0.0
+    end
+    
+    true
   end
 end
 

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -12,7 +12,7 @@ Sentry.init do |config|
     # prints env, and you can see "REQUEST_METHOD"=>"GET" on it
     # puts env
 
-    request_method = env[:REQUEST_METHOD]
+    request_method = env["REQUEST_METHOD"]
 
     # prints blank, "", nothing
     puts request_method 


### PR DESCRIPTION
## Overview

- Filter out OPTIONS and favicon.ico requests becasue the sdk will send them as transactions. We don't want transactions for these.
- Upgrade SDK to 5.4.1, from 5.0.1
- Removed sentry-ruby-core from Gemfile.lock, because sentry-ruby sdk no longer depends on it.
- added Gemfile.lock to source control because that's where the sentry-ruby sdk version is tracked.

Note: future sdk versions may auto filter out the OPTIONS requests. But we can leave our example in place because it's a good example, it should be harmless. Other platforms (sdks) still need this feature.

## Testing
[the events in Discover](https://sentry.io/organizations/testorg-az/discover/results/?end=2022-08-10T13%3A28%3A00&field=title&field=project&field=http.url&field=http.method&field=trace&field=sdk.version&field=timestamp&name=All+Events&project=6231039&query=url%3A%22https%3A%2F%2Fstaging%2A%22+event.type%3Atransaction&sort=-timestamp&start=2022-08-10T12%3A57%3A51&yAxis=count%28%29)

Before deploy to staging, OPTIONS
![image](https://user-images.githubusercontent.com/8920574/183912874-600fb761-dca3-45b4-b169-2c4362c9c807.png)

After deploy to staging,
![image](https://user-images.githubusercontent.com/8920574/183913426-b977b06e-13e2-4720-adb7-447f46ade9d4.png)
