### PR TITLE
[IGNORE] Dynamic Sampling - React Router v5 and SentryRoute Upgrade

### DIFF
--- a/react/src/components/About.js
+++ b/react/src/components/About.js
@@ -16,7 +16,7 @@ const employees = [Jane, Lily, Keith, Mason, Emma, Noah];
 class About extends Component {
 
   async shouldComponentUpdate() {
-    console.log("> About shouldComponentUpdate")
+    // console.log("> About shouldComponentUpdate")
   }
 
   async componentDidMount() {

--- a/react/src/components/Cart.js
+++ b/react/src/components/Cart.js
@@ -11,7 +11,7 @@ class Cart extends Component {
   static contextType = Context;
 
   async shouldComponentUpdate() {
-    console.log("> Cart shouldComponentUpdate")
+    // console.log("> Cart shouldComponentUpdate")
   }
 
   render() {

--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -20,7 +20,7 @@ class Checkout extends Component {
   }
 
   async shouldComponentUpdate() {
-    console.log("> Checkout shouldComponentUpdate")
+    // console.log("> Checkout shouldComponentUpdate")
   }
 
   handleInputChange(event) {

--- a/react/src/components/Employee.js
+++ b/react/src/components/Employee.js
@@ -12,7 +12,7 @@ class Employee extends Component {
   }
 
   async shouldComponentUpdate() {
-    console.log("> Employee shouldComponentUpdate")
+    // console.log("> Employee shouldComponentUpdate")
   }
 
   async componentDidMount() {

--- a/react/src/components/Footer.js
+++ b/react/src/components/Footer.js
@@ -4,7 +4,7 @@ import './footer.css';
 
 class Footer extends Component {
   async shouldComponentUpdate() {
-    console.log("> Footer shouldComponentUpdate")
+    // console.log("> Footer shouldComponentUpdate")
   }
 
   render() {

--- a/react/src/components/Home.js
+++ b/react/src/components/Home.js
@@ -13,7 +13,7 @@ class Home extends Component {
     static contextType = Context;
 
     async shouldComponentUpdate() {
-      console.log("> Home shouldComponentUpdate")
+      // console.log("> Home shouldComponentUpdate")
     }
   
     async componentDidMount() {

--- a/react/src/components/Product.js
+++ b/react/src/components/Product.js
@@ -52,8 +52,7 @@ class Product extends Component {
   
   render() {
     const { product } = this.state;
-    const { cart } = this.context;
-
+    console.log("> PRODUCT this", this)
     let averageRating
     if (product) {
       averageRating = (product.reviews.reduce((a,b) => a + (b["rating"] || 0),0) / 3).toFixed(1)

--- a/react/src/components/Product.js
+++ b/react/src/components/Product.js
@@ -21,7 +21,7 @@ class Product extends Component {
   }
 
   async shouldComponentUpdate() {
-    console.log("> Product shouldComponentUpdate")
+    // console.log("> Product shouldComponentUpdate")
   }
 
   async componentDidMount() {
@@ -52,7 +52,6 @@ class Product extends Component {
   
   render() {
     const { product } = this.state;
-    console.log("> PRODUCT this", this)
     let averageRating
     if (product) {
       averageRating = (product.reviews.reduce((a,b) => a + (b["rating"] || 0),0) / 3).toFixed(1)

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -59,7 +59,7 @@ class Products extends Component {
   }
 
   async shouldComponentUpdate() {
-    console.log("> Products shouldComponentUpdate")
+    // console.log("> Products shouldComponentUpdate")
   }
 
   async componentDidMount(){

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -42,7 +42,7 @@ class ProductsJoin extends Component {
   }
 
   async shouldComponentUpdate() {
-    console.log("> ProductsJoin shouldComponentUpdate")
+    // console.log("> ProductsJoin shouldComponentUpdate")
   }
 
   async componentDidMount(){

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -51,18 +51,21 @@ console.log("ENVIRONMENT", ENVIRONMENT)
 console.log("RELEASE", RELEASE)
 
 // Make sure the order of the routes is correct. The longest url under the same parent should be placed first and in decreasing order.
-// const routes = [
-//   { path: '/products-join'},
-//   { path: '/employee/:id'},
-//   { path: '/checkout'},
-//   { path: '/complete'},
-//   { path: '/products'},
-//   { path: '/about'}, 
-//   { path: '/error'},
-//   { path: '/cart'},
-//   { path: '/cra'},
-//   { path: '/' }
-// ];
+// '/product/:id is the only one that uses  <SentryRoute>, and the 4 commented out below :)
+const routes = [
+  // { path: '/products-join'},
+  { path: '/employee/:id'},
+  // { path: '/checkout'},
+  // { path: '/complete'},
+  // { path: '/products'},
+  // { path: '/about'}, 
+  // { path: '/error'},
+  // { path: '/cart'},
+  // { path: '/cra'},
+  // { path: '/' }
+];
+// 1. turn them all into <SentryRoute>
+// 2. the one that needs BACKEND_URL passed in, use the render technique
 
 Sentry.init({
   dsn: DSN,
@@ -172,32 +175,29 @@ class App extends Component {
 
             <div id="body-container">
               <Switch>
-                <Route exact path="/">
-                  <Home backend={BACKEND_URL} />
-                </Route>
-                <Route path="/about">
-                  <About backend={BACKEND_URL} history={history} />
-                </Route>
-                <Route path="/cart" component={Cart} />
-                <Route path="/checkout">
-                  <Checkout backend={BACKEND_URL} history={history} />
-                </Route>
-                <Route path="/complete" component={Complete} />
-                <Route path="/error" component={CompleteError} />
-                <Route path="/cra" component={Cra} />
+                <SentryRoute exact path="/" render={routeProps => (
+                    <Home {...routeProps} backend={BACKEND_URL}/>
+                )}></SentryRoute>
+                <SentryRoute path="/about" render={routeProps => (
+                    <About {...routeProps} backend={BACKEND_URL} history={history} />
+                )}></SentryRoute>
+                <SentryRoute path="/cart" component={Cart}></SentryRoute>
+                <SentryRoute path="/checkout" render={routeProps => (
+                    <Checkout {...routeProps} backend={BACKEND_URL} history={history} />
+                )}></SentryRoute>
+                <SentryRoute path="/complete" component={Complete}></SentryRoute>
+                <SentryRoute path="/error" component={CompleteError}></SentryRoute>
+                <SentryRoute path="/cra" component={Cra}></SentryRoute>
                 {/* Parameterization of the Employee Pages is done by beforeNavigate  */}
                 <Route path="/employee/:id" component={Employee} />
-                {/* Parameterizes the Product Page transactions */}
-                <SentryRoute path="/product/:id" render={routeProps => (
-                    <Product {...routeProps} backend="myvalue" />
+                <SentryRoute path="/product/:id" component={Product}></SentryRoute>
+                <SentryRoute path="/products" render={routeProps => (
+                    <Products {...routeProps} backend={BACKEND_URL}/>
                 )}></SentryRoute>
-                <Route path="/products">
-                  <Products backend={BACKEND_URL} />
-                </Route>
-                <Route path="/products-join">
-                  <ProductsJoin backend={BACKEND_URL} />
-                </Route>
-                <Route component={NotFound} />
+                <SentryRoute path="/products-join" render={routeProps => (
+                    <ProductsJoin {...routeProps} backend={BACKEND_URL}/>
+                )}></SentryRoute>
+                <SentryRoute component={NotFound}></SentryRoute>
               </Switch>
             </div>
             <Footer />

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -5,7 +5,7 @@ import "react-loader-spinner/dist/loader/css/react-spinner-loader.css";
 import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 import { createBrowserHistory } from 'history';
-import { Router, Switch, Route } from 'react-router-dom';
+import { Router, Switch, Route, matchPath } from 'react-router-dom';
 import { crasher } from './utils/errors'
 import { determineBackendType, determineBackendUrl } from './utils/backendrouter'
 import release from './utils/release'
@@ -50,6 +50,20 @@ const RELEASE = release("application.monitoring.javascript") || process.env.REAC
 console.log("ENVIRONMENT", ENVIRONMENT)
 console.log("RELEASE", RELEASE)
 
+// Make sure the order of the routes is correct. The longest url under the same parent should be placed first and in decreasing order.
+// const routes = [
+//   { path: '/products-join'},
+//   { path: '/employee/:id'},
+//   { path: '/checkout'},
+//   { path: '/complete'},
+//   { path: '/products'},
+//   { path: '/about'}, 
+//   { path: '/error'},
+//   { path: '/cart'},
+//   { path: '/cra'},
+//   { path: '/' }
+// ];
+
 Sentry.init({
   dsn: DSN,
   release: RELEASE,
@@ -58,7 +72,7 @@ Sentry.init({
   integrations: [
     new Integrations.BrowserTracing({
       tracingOrigins: tracingOrigins,
-      routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),
+      routingInstrumentation: Sentry.reactRouterV5Instrumentation(history, matchPath),
       _metricOptions: {
         _reportAllChanges: true,
       },
@@ -174,7 +188,9 @@ class App extends Component {
                 {/* Parameterization of the Employee Pages is done by beforeNavigate  */}
                 <Route path="/employee/:id" component={Employee} />
                 {/* Parameterizes the Product Page transactions */}
-                <SentryRoute path="/product/:id" component={Product}></SentryRoute>
+                <SentryRoute path="/product/:id" render={routeProps => (
+                    <Product {...routeProps} backend="myvalue" />
+                )}></SentryRoute>
                 <Route path="/products">
                   <Products backend={BACKEND_URL} />
                 </Route>


### PR DESCRIPTION

### React Router sentry documentation
https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#react-router-v6

https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#react-router-v4v5

### How to Pass Props to SentryRoute
```
<SentryRoute path="/product/:id" render={routeProps => (
                    <Product {...routeProps} backend="myvalue" />
                )}></SentryRoute>
```

If we switch to React Router v6, we may lose purpose in using beforeNavigate, as it would now get grouped+parameterized correctly via `<SentryRoutes>` wrapping all `<Route>'s`.