### PR TITLE
Update deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,6 @@
 RELEASE=`./release.sh`
 PACKAGE_NAME=application.monitoring.javascript
+ENVIRONMENT=production
 
 RELEASE=$PACKAGE_NAME@$RELEASE
 echo $RELEASE
@@ -14,8 +15,10 @@ npm install
 npm run build
 
 sentry-cli releases -o $SENTRY_ORG new -p $SENTRY_PROJECT $RELEASE
+sentry-cli releases -o $SENTRY_ORG finalize -p $SENTRY_PROJECT $RELEASE
 sentry-cli releases -o $SENTRY_ORG -p $SENTRY_PROJECT set-commits --auto $RELEASE
 sentry-cli releases -o $SENTRY_ORG -p $SENTRY_PROJECT files $RELEASE upload-sourcemaps --url-prefix "~/static/js" --validate build/$PREFIX
+sentry-cli deploys -o $SENTRY_ORG new -p $SENTRY_PROJECT -r $RELEASE -e $ENVIRONMENT -n $ENVIRONMENT
 
 # This deploys React - The release was set in the static prod build
 gcloud app deploy --quiet


### PR DESCRIPTION
Updated deploy.sh to Finalize Release and add production tag.

[Release finalization ](https://docs.sentry.io/product/cli/releases/#finalizing-releases) is intended to explicitly define what is considered as the "next release" (for purposes of fixing issues) as well as  aligning commits.  No evidence finalizing a release impacts sentry.io UI's sort order in the Release tab (see GIF)

![Sentry Release Finalization](https://user-images.githubusercontent.com/17515078/189939655-32e5fd00-db73-450f-b652-3528e716e77a.gif)
