### PR TITLE
Frontend use only 4 Products

### DIFF
--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -66,7 +66,8 @@ class Products extends Component {
     var products
     try {
       products = await this.getProducts();
-      this.props.setProducts(products)
+      // take first 4 products because that's all we have img/title/description for
+      this.props.setProducts(products.slice(0,4))
     } catch(err) {
       Sentry.captureException(new Error("app unable to load products: " + err));
     }


### PR DESCRIPTION
## Overview
The /products response from the backend will soon serve more than 4 products, but we only have enough content to populate 4 of them on the frontend.

The backend will soon query more than 4 so that it creates a Performance Issue, as +5 sql queries in a N+1 query are needed in order to trigger a Performance Issue. Currently there are only 4 sql queries made in the 'products endpoints, not 5. It's +1 query to the sql reviews table for each product 'n, of which there are only 4.

This needs to be deployed to Prod before adding more rows to the products and reviews tables in the database.

## Testing
[/products](https://sentry.io/organizations/testorg-az/discover/application-monitoring-javascript:2ba5d831e9ac4218962f958fee1f80c5/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&query=se%3Awill+project%3Aapplication-monitoring-javascript&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29) transaction still working

[checkout](https://sentry.io/organizations/testorg-az/performance/trace/fc2ba0dc283a4923aba0f2f215f672e6/?statsPeriod=1h) trace still looking right

## Result
Now, you can add more rows to the database and the live production app will not be overserving more than the frontend can handle, which could end up in blank productcards or Errors.