### PR TITLE
[Actions] Sync *-deploy fork with latest changes in this repo

### DIFF
--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -28,7 +28,7 @@ jobs:
         run: git remote add -f upstream https://github.com/sentry-demos/application-monitoring
           
       - name: Merge in latest changes
-        run: git rebase upstream/master
+        run: git rebase upstream/master || git diff --diff-filter=U --relative
       
       - name: Push (force)
         run: git push -f

--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sentry-demos/application-monitoring-deploy
+          fetch-depth: 0
           token: ${{ secrets.KOSTY_PERSONAL_ACCESS_TOKEN_FOR_SYNC_DEPLOY_FORK }}
 
       

--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sentry-demos/application-monitoring-deploy
+          token: ${{KOSTY_PERSONAL_ACCESS_TOKEN_FOR_SYNC_DEPLOY_FORK}}
+
       
       - name: Add and fetch *this* repo (`sentry-demos/application-monitoring`)
         run: git remote add -f upstream https://github.com/sentry-demos/application-monitoring

--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -27,6 +27,11 @@ jobs:
       
       - name: Add and fetch *this* repo (`sentry-demos/application-monitoring`)
         run: git remote add -f upstream https://github.com/sentry-demos/application-monitoring
+        
+      - name: Configure User email
+        run: |
+            git config --global user.email "kosty.maleyev@sentry.io"
+            git config --global user.name "sync-deploy-fork on behalf of Kosty Maleyev"
           
       - name: Merge in latest changes
         run: git rebase upstream/master || git diff --diff-filter=U --relative

--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sentry-demos/application-monitoring-deploy
-          token: ${{KOSTY_PERSONAL_ACCESS_TOKEN_FOR_SYNC_DEPLOY_FORK}}
+          token: ${{ secrets.KOSTY_PERSONAL_ACCESS_TOKEN_FOR_SYNC_DEPLOY_FORK }}
 
       
       - name: Add and fetch *this* repo (`sentry-demos/application-monitoring`)

--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -1,0 +1,34 @@
+name: Sync sentry-demos/application-monitoring-deploy with latest changes in this repo
+run-name: Sync deploy fork triggered by ${{ github.event_name }} / ${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - 'master'
+    
+jobs:
+  default-job:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - run: echo "Triggered by ${{ github.event_name }} event."
+      - run: echo "Branch is ${{ github.ref }}"
+      
+      - name: Check out `application-monitoring-deploy`
+        uses: actions/checkout@v3
+        with:
+          repository: sentry-demos/application-monitoring-deploy
+      
+      - name: Add and fetch *this* repo (`sentry-demos/application-monitoring`)
+        run: git remote add -f upstream https://github.com/sentry-demos/application-monitoring
+          
+      - name: Merge in latest changes
+        run: git rebase upstream/master
+      
+      - name: Push (force)
+        run: git push -f
+      
+      - run: echo "Job status is ${{ job.status }}."

--- a/.github/workflows/sync-deploy-fork.yml
+++ b/.github/workflows/sync-deploy-fork.yml
@@ -1,5 +1,5 @@
-name: Sync sentry-demos/application-monitoring-deploy with latest changes in this repo
-run-name: Sync deploy fork triggered by ${{ github.event_name }} / ${{ github.actor }}
+name: Sync *-deploy fork with latest changes in this repo
+run-name: Sync *-deploy fork triggered by ${{ github.event_name }} / ${{ github.actor }}
 
 on:
   push:


### PR DESCRIPTION
Automatically think any new changes in application-monitoring master branch to the private fork:
https://github.com/sentry-demos/application-monitoring-deploy/

Any changes in the private fork are rebased on top of latest upstream, so commits unique to the fork appear at the very top.
(also, technically *-deploy is not a fork because GH does not allow private forks of public repos, instead it's an [exact copy of the original repository](https://stackoverflow.com/questions/10065526/github-how-to-make-a-fork-of-public-repository-private) but GitHub is not aware of it)

The idea is that there will be no conflicts because *-deploy will only have the following changes that will never overlap with upstream changes (unless someone does something extra stupid):

1. environment config files (right now: `.env`, `app.yaml`; with the upcoming new deployment script: `env-config/*.env` ) that are **gitignore'd** in the upstream repo
2. `.github/workflows/auto-deploy.yml` - unique to this repo.

Testing:
[successful run](https://github.com/sentry-demos/application-monitoring-testfork/actions/runs/3270449832/jobs/5379082553)
Output: https://github.com/sentry-demos/application-monitoring-deploy/commits/master