### PR TITLE
New deploy v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ or
 ./deploy.sh react --env=local
 ```
 
-### ~~2) Run React app w/ hot reload~~ (not supported right now)
+### 2) Run React app w/ hot reload
 NOTE: this will cause crashing errors to be tagged in sentry as handled (`handled: true`)
 ```
-npm start
-Running React app w/ hot reload is not supported right now
+cd react
+../env.sh local npm start
 ```
 
 ## Trigger an error

--- a/bin/sentry-release.sh
+++ b/bin/sentry-release.sh
@@ -1,25 +1,34 @@
 #!/bin/bash
 
-USAGE="Usage: ./sentry-release.sh SENTRY_ORG SENTRY_PROJECT ENVIRONMENT RELEASE SOURCEMAPS_URL_PREFIX SOURCEMAPS_DIR"
+# Create release and upload sourcemaps to Sentry
+# Must be run within project directory (e.g. './react/')
+
+USAGE="Usage: ./sentry-release.sh ENV RELEASE"
 
 set -e # exit immediately if any command exits with a non-zero status
 
 # Parse and validate command-line arguments
-sentry_org="$1"
-sentry_project="$2"
-environment="$3"
-release="$4"
-sourcemaps_url_prefix="$5"
-sourcemaps_dir="$6"
-if [[ "$sentry_org" == "" || "$sentry_project" == "" || "$environment" == "" || "$release" == "" \
-      || "$sourcemaps_url_prefix" == "" || "$sourcemaps_dir" == "" ]]; then
-  echo "build_and_upload_sourcemaps.sh: [error] missing required command-line arguments."
+env="$1"
+release="$2"
+if [[ "$env" == "" || "$release" == "" ]]; then
+  echo "$0: [error] missing required command-line arguments."
   echo $USAGE
   exit 1
 fi
 
-sentry-cli releases -o $sentry_org new -p $sentry_project $release
-sentry-cli releases -o $sentry_org finalize -p $sentry_project $release
-sentry-cli releases -o $sentry_org -p $sentry_project set-commits --auto $release --ignore-missing
-sentry-cli releases -o $sentry_org -p $sentry_project files $release upload-sourcemaps --url-prefix "$sourcemaps_url_prefix" --validate "$sourcemaps_dir" 
-sentry-cli deploys -o $sentry_org new -p $sentry_project -r $release -e $environment -n $environment
+proj=$(basename $(pwd))
+    
+if [ "$SENTRY_ORG" == "" ]; then
+  echo "$0 [ERROR] SENTRY_ORG must be defined in ./env-config/$env.env."
+  exit 1
+fi
+# sets $sentry_project var to the value of e.g. REACT_SENTRY_PROJECT from env-config/<env>.env
+. get_proj_var.sh "%s_SENTRY_PROJECT" $proj
+. get_proj_var.sh "%s_SOURCEMAPS_URL_PREFIX" $proj
+. get_proj_var.sh "%s_SOURCEMAPS_DIR" $proj
+
+sentry-cli releases -o $SENTRY_ORG new -p $sentry_project $release
+sentry-cli releases -o $SENTRY_ORG finalize -p $sentry_project $release
+sentry-cli releases -o $SENTRY_ORG -p $sentry_project set-commits --auto $release --ignore-missing
+sentry-cli releases -o $SENTRY_ORG -p $sentry_project files $release upload-sourcemaps --url-prefix "$sourcemaps_url_prefix" --validate "$sourcemaps_dir" 
+sentry-cli deploys -o $SENTRY_ORG new -p $sentry_project -r $release -e $env -n $env

--- a/bin/source_diff_upstream.sh
+++ b/bin/source_diff_upstream.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Outputs diff --stat between the current working tree and master branch of
+# sentry-demos/application-monitoring
+
+UPSTREAM_BRANCH="master"
+UPSTREAM_URL="git@github.com:sentry-demos/application-monitoring-deploy.git"
+ALT_UPSTREAM_URL="https://github.com/sentry-demos/application-monitoring-deploy.git"
+
+remote=$(git remote -v | grep $UPSTREAM_URL | head -1 | cut -f 1)
+if [ "$remote" == "" ]; then
+  remote=$(git remote -v | grep $ALT_UPSTREAM_URL | head -1 | cut -f 1)
+fi
+if [ "$remote" == "" ]; then
+  remote="deploy"
+  git remote add $remote $UPSTREAM_URL >/dev/null
+fi
+
+git fetch $remote >/dev/null
+
+git diff --stat $remote/$UPSTREAM_BRANCH -- ':!.github/workflows/auto-deploy.yml' ':!env-config/*.env'
+git diff --stat $remote/$UPSTREAM_BRANCH:env-config/production.env env-config/production.env

--- a/bin/validate_dotenv.sh
+++ b/bin/validate_dotenv.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Variables must be defined in .env file, not current shell. Exports into current
+# shell work with run.sh but won't be carried over to GCloud runtime environment.
+#
+# For React specifically:
+#
+#   REACT_APP_MY_VAR=foobar npm run build
+# 
+#   Names must be prefixed with 'REACT_APP_', otherwise they will not show up
+#
+#   See https://create-react-app.dev/docs/adding-custom-environment-variables
+
+set -e # exit immediately if any command exits with a non-zero status
+  
+if [ ! -f .env ]; then
+    echo "$0: ERROR: .env does not exist in current directory: $(pwd). It should have been
+    created by 'parent' script."
+    exit 1
+fi
+
+env -i PATH="$PATH" SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" /bin/bash -c 'export $(grep -v ^# .env | xargs); validate_env.sh'
+ 

--- a/bin/validate_dsn.sh
+++ b/bin/validate_dsn.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+sentry_project="$1"
+dsn="$2"
+error_message="$3"
+
+# Verify that <PROJ>_SENTRY_PROJECT and <PROJ>_APP_DSN point to the same project
+if [ "$SENTRY_AUTH_TOKEN" == "" ]; then
+    echo "$0 [ERROR] SENTRY_AUTH_TOKEN must be defined. See https://docs.sentry.io/product/cli/configuration/
+        In GitHub Actions environment this means that corresponding secret is not set."
+    exit 2
+fi
+api_response=$(curl https://sentry.io/api/0/projects/ \
+    -H 'Authorization: Bearer '"$SENTRY_AUTH_TOKEN" 2>/dev/null)
+id_proj=$(echo "$api_response" | grep -Eo '"id":"([^"]*)","slug":"(.*?)"' | sed 's/"id":"//g' | sed 's/","slug":"/ /g' | sed 's/"//g')
+
+project_id_from_slug=$(echo "$id_proj" | grep $sentry_project | head -1 | cut -d ' ' -f 1)
+if [ "$project_id_from_slug" == "" ]; then
+    echo "$0 [ERROR] Unable to get project id using Sentry API. Wrong auth token? Response:"
+    echo "$resp"
+    exit 2
+fi
+
+project_id_from_dsn=$(echo $dsn | cut -d / -f 4)
+if [ "$project_id_from_slug" != "$project_id_from_dsn" ]; then
+    echo "$0 [ERROR] $error_message"
+    exit 1
+fi
+
+exit 0

--- a/bin/validate_env.sh
+++ b/bin/validate_env.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
 
-# Variable can be either defined in .env file
-# or in the shell when calling command, e.g.:
+# Checks if all variables listed in <current dir>/validate_env.sh are present
+# in the current shell environment (i.e. exported)
+# Additionally, verifies that Sentry project slug and DSN match.
 #
-# REACT_APP_MY_VAR=foobar npm run build
-# 
-# Names must be prefixed with 'REACT_APP_', otherwise they will not show up
-#
-# See https://create-react-app.dev/docs/adding-custom-environment-variables
+# Must be run from within project dir (e.g. './react/')
 
 set -e # exit immediately if any command exits with a non-zero status
-
-if [ -f .env ]; then
-  source .env
-fi
 
 if [ ! -f validate_env.list ]; then
   echo "$0: ERROR: validate_env.list file does not exist in current directory: $(pwd)"
@@ -30,16 +23,17 @@ while read var || [[ -n $var ]]; do # won't skip last line if missing line break
   #   value=$(printenv $var)
   #   match=$(grep -e "^$var=" .env | cut -d '=' -f 2)
   
-  # Note this relies on 'source .env' above
-  # but will also work with exported variables 
   value="${!var}" # won't work in zsh, only bash
 
   if [ "$value" == "" ]; then
-    >&2 echo "validate_env.sh: [ERROR] required env variable $var not defined or has empty value." \
-             "You must add it to your env-config/*.env file." 
+    >&2 echo "$0: [ERROR] required env variable $var not defined or has empty value." \
+            "You must add it to your env-config/*.env file." 
     exit 1
-  else
-    echo "validate_env.sh: verified $var is set."
   fi
 done < validate_env.list
-
+  
+proj=$(basename $(pwd))
+. get_proj_var.sh "%s_APP_DSN" $proj
+. get_proj_var.sh "%s_SENTRY_PROJECT" $proj
+error_message=$(var_name.sh "%s_SENTRY_PROJECT and %s_APP_DSN point to different projects." $proj $proj)
+validate_dsn.sh $sentry_project $app_dsn $error_message

--- a/bin/validate_project.sh
+++ b/bin/validate_project.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+path="$1"
+proj=$(basename $path)
+
+set -e 
+  
+if [ ! -d $path ]; then
+    echo "[ERROR] Project '$proj' does not exist"
+    exit 1
+elif [ -f "$path/app.yaml" ]; then 
+    echo "[ERROR] project '$proj' contains legacy app.yaml file that is no longer used. Please delete this file,
+    it is no longer be needed and has been replaced by app.yaml.template."
+    exit 1
+elif [ ! -f "$path/app.yaml.template" ]; then
+    echo "[ERROR] Missing $proj/app.yaml.template with '<SERVICE>' placeholder in place of actual service name."
+    exit 1
+fi

--- a/bin/verify_latest_code.sh
+++ b/bin/verify_latest_code.sh
@@ -18,4 +18,5 @@ fi
 
 git fetch $remote >/dev/null
 
-git diff --stat $remote/$UPSTREAM_BRANCH
+git diff --stat $remote/$UPSTREAM_BRANCH -- ':!.github/workflows/auto-deploy.yml' ':!env-config/*.env'
+git diff --stat $remote/$UPSTREAM_BRANCH:env-config/production.env env-config/production.env

--- a/bin/verify_latest_code.sh
+++ b/bin/verify_latest_code.sh
@@ -1,22 +1,24 @@
 #!/bin/bash
 
-# Outputs diff --stat between the current working tree and master branch of
-# sentry-demos/application-monitoring
+set -e
 
-UPSTREAM_BRANCH="master"
-UPSTREAM_URL="git@github.com:sentry-demos/application-monitoring-deploy.git"
-ALT_UPSTREAM_URL="https://github.com/sentry-demos/application-monitoring-deploy.git"
+diff="$(source_diff_upstream.sh)"
 
-remote=$(git remote -v | grep $UPSTREAM_URL | head -1 | cut -f 1)
-if [ "$remote" == "" ]; then
-  remote=$(git remote -v | grep $ALT_UPSTREAM_URL | head -1 | cut -f 1)
+if [ "$diff" != "" ]; then
+    echo "You are about to do a deployment to production, but current code is different from HEAD at
+    sentry-demos/application-monitoring AND/OR your production.env is different from production.env in 
+    sentry-demos/application-monitoring-deploy:"
+    MAX_DIFF_LINES="7"
+    difflines="$(echo "$diff" | wc -l)"
+    diff="$(echo -n "$diff" | head -$MAX_DIFF_LINES)"
+    echo "$diff"
+    if [ "$difflines" -gt "$MAX_DIFF_LINES" ]; then
+        echo " ... ($((difflines - $MAX_DIFF_LINES)) more lines)"
+    fi
+    phrase="yes, deploy to production"
+    read -p "Type '$phrase' to continue... " choice
+    if [ "$choice" != "$phrase" ]; then
+        echo "Exiting without performing command."
+        exit 1
+    fi
 fi
-if [ "$remote" == "" ]; then
-  remote="deploy"
-  git remote add $remote $UPSTREAM_URL >/dev/null
-fi
-
-git fetch $remote >/dev/null
-
-git diff --stat $remote/$UPSTREAM_BRANCH -- ':!.github/workflows/auto-deploy.yml' ':!env-config/*.env'
-git diff --stat $remote/$UPSTREAM_BRANCH:env-config/production.env env-config/production.env

--- a/deploy.sh
+++ b/deploy.sh
@@ -82,8 +82,9 @@ if [ -t 0 ] ; then
     diff="$(verify_latest_code.sh)"
     if [ "$diff" != "" ]; then
       echo "You are about to do a deployment to production, but current code is different from HEAD at
+       sentry-demos/application-monitoring AND/OR your production.env is different from production.env in 
        sentry-demos/application-monitoring-deploy:"
-      MAX_DIFF_LINES="3"
+      MAX_DIFF_LINES="7"
       difflines="$(echo "$diff" | wc -l)"
       diff="$(echo -n "$diff" | head -$MAX_DIFF_LINES)"
       echo "$diff"

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,10 +16,10 @@
 # All variables in *.env are passed into each projects runtime environment. 
 # Some variables, however, are special and are additionally used during the build:
 # 
-#   SENTRY_ORG is passed to ./build_and_upload_sourcemaps.sh and used to specify which Sentry
+#   SENTRY_ORG is passed to ./bin/sentry-release.sh and used to specify which Sentry
 #   org to create release in.
 #
-#   <PROJECT>_SENTRY_PROJECT is passed to ./build_and_upload_sourcemaps.sh and used to specify 
+#   <PROJECT>_SENTRY_PROJECT is passed to ./bin/sentry-release.sh and used to specify 
 #   which Sentry project to create release in. 
 # 
 #   <PROJECT>_RELEASE_PACKAGE_NAME is used to create a new Sentry release (prepended to calendar
@@ -61,7 +61,7 @@ for arg in "$@"; do
     env=$(echo $arg | cut -d '=' -f 2)
     echo "env = $env"
   else 
-    projects="$projects $arg"
+    projects+="$arg "
   fi
 done
 
@@ -73,31 +73,9 @@ if [[ "$env" == "" || "$projects" == "" ]]; then
   exit 1
 fi
 
-# Validate using latest code if --env=production
-if [ -t 0 ] ; then
-  # shell is interactive
-  if [ "$env" == "production" ]; then
-    echo "Verifying that the code in the current git working tree, branch and fork is identical
-         to the default branch of upstream repository (sentry-demos/application-monitoring)..."
-    diff="$(verify_latest_code.sh)"
-    if [ "$diff" != "" ]; then
-      echo "You are about to do a deployment to production, but current code is different from HEAD at
-       sentry-demos/application-monitoring AND/OR your production.env is different from production.env in 
-       sentry-demos/application-monitoring-deploy:"
-      MAX_DIFF_LINES="7"
-      difflines="$(echo "$diff" | wc -l)"
-      diff="$(echo -n "$diff" | head -$MAX_DIFF_LINES)"
-      echo "$diff"
-      if [ "$difflines" -gt "$MAX_DIFF_LINES" ]; then
-        echo " ... ($((difflines - $MAX_DIFF_LINES)) more lines)"
-      fi
-      phrase="yes, deploy to production"
-      read -p "Type '$phrase' to continue... " choice
-      if [ "$choice" != "$phrase" ]; then
-          echo "Exiting without performing command."
-          exit 1
-      fi
-    fi
+if [ "$env" == "production" ]; then
+  if [ -t 0 ] ; then # shell is interactive
+    verify_latest_code.sh
   fi
 fi
 
@@ -128,104 +106,48 @@ trap cleanup EXIT
 run_sh_pids=""
 
 for proj in $projects; do # bash only
-  # Validate configuration files
-  if [ ! -d $top/$proj ]; then
-    echo "[ERROR] Project '$proj' does not exist"
-    exit 1
-  fi
-  if [ ! -f "$top/env-config/$env.env" ]; then
-    echo "[ERROR] Missing file ./env-config/$env.env"
-    exit 1
-  elif [ -f "$top/$proj/app.yaml" ]; then 
-    echo "[ERROR] project '$proj' contains app.yaml file that is no longer used. Please delete this file,
-    it is no longer be needed and has been replaced by app.yaml.template."
-    exit 1
-  elif [ -f "$top/$proj/.env" ]; then
-    echo "[ERROR] project '$proj' contains .env file that is no longer used. Please delete this file,
-    it is no longer needed and has been replaced by ./env-config/*.env. Note that this error
-    might also happen if deploy.sh failed to clean up the .env file it has generated dynamically during
-    an earlier run."
-    # we make sure not to delete any pre-existing .env files during cleanup, see 'generated_envs'
-    exit 1
-  elif [ ! -f "$top/$proj/app.yaml.template" ]; then
-    echo "[ERROR] Missing ./$proj/app.yaml.template with '<SERVICE>' placeholder in place of actual service name."
-    exit 1
-  fi
 
-  # Export environment variables from ./env-config/<env>.env
-  # Some projects still rely on .env so we generate it dynamicaly later down the road
-  while read line || [[ -n $line ]]; do # won't skip last line if missing line break
-    if [[ ! $line = \#* && $line = *[![:space:]]* ]]; then # ignore comments and empty lines
-      export "$line"
-    fi
-  done < $top/env-config/$env.env
+  echo "|||"
+  echo "||| $0: $proj"
+  echo "|||"
 
+  validate_project.sh $top/$proj 
+  
+  cd $top/$proj
+
+  # React bakes in (exported) env variables from calling shell as well as contents of .env
+  # at build time into the static build output. As a result it doesn't need .env at runtime.
+  # See: https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/config/env.js
+  # and https://create-react-app.dev/docs/adding-custom-environment-variables/
+  #
+  # Express and Flask on the other hand need .env deployed and present at runtime. 
+  #
+  # We generate a temporary .env dynamically from env-config/*.env then remove upon exit
+  generated_envs+="$(../env.sh $env) "
+  
+  # We do this because 1) we need RELEASE that's generated in env.sh 2) we need *_APP_*_BACKEND
+  # 3) some projects may require env variables instead of .env (not the case for react, flask & express)
+  # TODO: support spring-boot which seems to use .properties files
+  export $(grep -v '^#' .env | xargs) 
+    
   if [[ "$env" == "local" && "$fe_projects" = *"$proj "* ]]; then 
-    # Point to local backend http://host:port instead of cloud endpoints for all built BE projects
+    # Point to local backend http://host:port instead of cloud endpoints for all _built_ BE projects
     # If no backend projects specified in CLI args, keep using cloud (production or staging) BE endpoints.
     for be_proj in $be_projects; do
       backend_var=$(var_name.sh %s_APP_%s_BACKEND $proj $be_proj)
       . get_proj_var.sh "%s_APP_%s_BACKEND_LOCAL" $proj $be_proj # sets $app_backend_local
+      echo "" >> .env # in case no newline
+      echo "$backend_var=$app_backend_local" >> .env # append instead of search-replace should be OK
       export "$backend_var=$app_backend_local"
     done 
   fi
-  
-  cd $top/$proj
 
-  # *** BUILD ***
-  . get_proj_var.sh "%s_RELEASE_PACKAGE_NAME" $proj
-  release="${release_package_name}@"`release.sh`
-  echo $release
-  # Existing behavior in react build. TODO: is this necessary?
-  if [ "$env" == "local" ]; then
-    rm -rf build
-    npm install
-  fi
-  if [[ ! -z $CI ]]; then
-    # a clean repository will be be checked out every time in a CI pipeline
-    npm install
-  fi
-  unset CI # prevents build failing on warnings when run in GitHub Actions
-  export RELEASE="$release"
-  ./build.sh "$release"
+  unset CI # prevents build failing in GitHub Actions
+  ./build.sh
 
-  # *** CREATE RELEASE AND UPLOAD SOURCEMAPS ***
-  if [[ "$fe_projects" = *"$proj "* ]]; then # current project is frontend
-    # We don't create releases for backend projects because it's not part of demo flow and sourcemaps are not
-    # necessary either. 
-    if [ "$SENTRY_ORG" == "" ]; then
-      echo "$0 [ERROR] SENTRY_ORG must be defined in ./env-config/$env.env."
-      exit 1
-    fi
-    # sets $sentry_project var to the value of e.g. REACT_SENTRY_PROJECT from env-config/<env>.env
-    . get_proj_var.sh "%s_SENTRY_PROJECT" $proj
-    . get_proj_var.sh "%s_SOURCEMAPS_URL_PREFIX" $proj
-    . get_proj_var.sh "%s_SOURCEMAPS_DIR" $proj
-    . get_proj_var.sh "%s_APP_DSN" $proj
-
-    # Verify that <PROJ>_SENTRY_PROJECT and <PROJ>_APP_DSN point to the same project
-    if [ "$SENTRY_AUTH_TOKEN" == "" ]; then
-      echo "$0 [ERROR] SENTRY_AUTH_TOKEN must be defined. See https://docs.sentry.io/product/cli/configuration/
-            In GitHub Actions environment this means that corresponding secret is not set."
-      exit 1
-    fi
-    api_response=$(curl https://sentry.io/api/0/projects/$SENTRY_ORG/$sentry_project/ \
-      -H 'Authorization: Bearer '"$SENTRY_AUTH_TOKEN" 2>/dev/null)
-    project_id_from_slug=$(echo "$api_response" | grep -Eo '"id":"(.*?)"' | head -1 | cut -d '"' -f 4)
-    if [ "$project_id_from_slug" == "" ]; then
-      echo "$0 [ERROR] Unable to get project id using Sentry API. Wrong auth token? Response:"
-      echo "$api_response"
-      exit 1
-    fi
-    project_id_from_dsn=$(echo $app_dsn | cut -d / -f 4)
-    if [ "$project_id_from_slug" != "$project_id_from_dsn" ]; then
-      message=$(var_name.sh "%s_SENTRY_PROJECT and %s_APP_DSN point to different projects." $proj $proj)
-      echo "$0 [ERROR] $message"
-      exit 1
-    fi
-
-    # Create release and upload sourcemaps to Sentry
-    sentry-release.sh "$SENTRY_ORG" "$sentry_project" "$env" "$release" "$sourcemaps_url_prefix" "$sourcemaps_dir"
+  if [[ "$fe_projects" = *"$proj "* ]]; then # project is frontend
+    sentry-release.sh $env $RELEASE
+    # NOTE: Sentry may create releases from events even without this step
   fi
 
   # *** DEPLOY OR RUN ***
@@ -234,23 +156,23 @@ for proj in $projects; do # bash only
     pid="$!"
     run_sh_pids+="$pid " # for later cleanup
 
-    sleep 5
-    if ! ps -p $pid > /dev/null
-    then
-      echo "$0 [ERROR]: $proj/run.sh exited early, must be a crash."
-      exit 1
+    if [[ "$projects" != *"$proj " ]]; then # not last one
+      sleep 1 
+      echo "$0: Waiting a few seconds before building next project to make sure this server process doesn't crash..."
+      sleep 4 
+      if ! ps -p $pid > /dev/null
+      then
+        echo "$0 [ERROR]: $proj/run.sh exited early, must be a crash."
+        exit 1
+      fi
     fi
   else
-    # At least some projects rely on .env file (flask, express) and don't seem to pick up 
-    # values from env variables
-    # We generate a temporary .env dynamically from env-config/*.env then remove upon exit
-    cp $top/env-config/$env.env $top/$proj/.env
-    generated_envs+="$top/$proj/.env "
 
-    # Get service variable name, <PROJECT>_APP_ENGINE_SERVICE
+    # Replace <SERVICE> in app.yaml.template with <PROJECT>_APP_ENGINE_SERVICE
     . get_proj_var.sh "%s_APP_ENGINE_SERVICE" $proj
-    sed -e 's/<SERVICE>/'$app_engine_service'/g' $top/$proj/app.yaml.template > $top/$proj/.app.yaml
-    gcloud app deploy --quiet $top/$proj/.app.yaml
+    sed -e 's/<SERVICE>/'$app_engine_service'/g' app.yaml.template > .app.yaml
+    
+    gcloud app deploy --quiet .app.yaml
   fi
 done
 

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Usage: ../env.sh env [command ...]
+#
+# Must be run from inside project dir (e.g. './react/')
+#
+# There are two modes in which this script can be run. Both will create a temporary
+# .env file in current directory by copying env-config/*.env, augment it with RELEASE
+# (if not already set in env-config) and validate it using 'validate_env.list'.
+#
+# In the first mode (called from deploy.sh with 1 arg) it won't do anything else.
+# Example:
+#   ../env.sh production
+#
+# In the second mode (standalone), when given more than one arg, it will additionally
+# run 2nd arg and the rest as command. Once the command exits it will clean up .env.
+# Example:
+#   ../env.sh local npm start
+
+set -e
+
+env=$1
+proj=$(basename $(pwd))
+
+if [ ! -f "../env-config/$env.env" ]; then
+  echo "[ERROR] Missing file env-config/$env.env or invalid environment '$env'."
+  exit 1
+fi
+if [ -f ".env" ]; then
+    echo "[ERROR] project '$proj' contains legacy .env file that is no longer used. Please delete this file,
+    it is no longer needed and has been replaced by ./env-config/*.env. Note that this error
+    might also happen if deploy.sh or env.sh failed to clean up the .env file it has generated dynamically 
+    during an earlier run."
+    exit 1
+fi
+if [ "$2" != "" ]; then
+    export PATH="$PATH:../bin"
+fi
+
+cp ../env-config/$env.env .env
+
+function cleanup {
+    rm -f .env
+}
+trap cleanup EXIT # if fails while running this script or while running command
+
+# You can specify RELEASE in env-config/*.env
+# Otherwise this script will generate one using this format:
+# <PROJ>_RELEASE_PACKAGE_NAME@<CALENDAR VERSION>
+
+echo "" >> .env # in case no newline
+# source .env will not work because of '$' symbols in values (PASSWORD)
+unset RELEASE # so we don't accidentally pick up RELEASE from another project (deploy.sh)
+export $(grep -v '^#' .env | xargs) # just for *_RELEASE_PACKAGE_NAME and RELEASE
+if [ "$RELEASE" == "" ]; then
+    . get_proj_var.sh "%s_RELEASE_PACKAGE_NAME" $proj
+    release="${release_package_name}@"`release.sh`
+    >&2 echo $release
+    # deploy.sh script itself and non-React projects expect RELEASE
+    echo "RELEASE=$release" >> .env
+    export RELEASE="$release"
+fi
+if [ "$proj" == "react" ]; then
+    echo "REACT_APP_RELEASE=$RELEASE" >> .env
+fi
+
+if [ "$2" == "" ]; then 
+    # Called from deploy.sh
+    #
+    # 1. Calling script will use .env, this script doen't have control over that.
+    # For that reason we pass it down to the calling script so it can clean up later.
+    # 2. We can't export variables into calling script, so the calling script is
+    # also responsible for that (not required for projects using dotenv package).
+    trap - EXIT
+    echo "$(pwd)/.env" 
+else
+    # Standalone mode
+
+    export $(grep -v '^#' .env | xargs) # in case project doesn't use dotenv
+
+    if [ "$proj" == "react" ]; then
+        # avoids error npm start tries to bind to every available network interface
+        HOST=localhost "${@:2}"
+    else
+        "${@:2}"
+    fi
+fi

--- a/flask/run.sh
+++ b/flask/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-RELEASE=`release.sh`
-
 if [ ! -d ./venv ]; then 
     python3 -m venv ./venv
 fi
@@ -16,4 +14,4 @@ function cleanup {
 }
 trap cleanup EXIT
 
-RELEASE=$RELEASE python3 main.py
+python3 main.py

--- a/react/build.sh
+++ b/react/build.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-# Usage: ./build.sh RELEASE
+# Usage: ./build.sh
 
 set -e # exit immediately if any command exits with a non-zero status
 
-if [ "$1" == "" ]; then
-  echo "$0 [ERROR]: missing RELEASE argument."
-  exit 1
-fi
-export REACT_APP_RELEASE="$1" # create-react-app requires all env vars start with REACT_APP_
-
+rm -rf build
+npm install
 npm run build # defined in 'scripts' in package.json

--- a/react/package.json
+++ b/react/package.json
@@ -19,8 +19,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "validate_env.sh && react-scripts start",
-    "build": "validate_env.sh && react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/react/src/components/Product.js
+++ b/react/src/components/Product.js
@@ -8,7 +8,7 @@ import productThree from './products/3';
 import productFour from './products/4';
 
 import { connect } from 'react-redux'
-import { setProducts, addProduct } from '../actions'
+import { /*setProducts,*/ addProduct } from '../actions'
 
 class Product extends Component {
   static contextType = Context;
@@ -52,7 +52,7 @@ class Product extends Component {
   
   render() {
     const { product } = this.state;
-    const { cart } = this.context;
+    //const { cart } = this.context;
 
     let averageRating
     if (product) {

--- a/react/src/components/Products.js
+++ b/react/src/components/Products.js
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import Context from '../utils/context';
-import { Link } from 'react-router-dom';
+//import { Link } from 'react-router-dom';
 import './products.css';
 import * as Sentry from '@sentry/react';
 import { connect } from 'react-redux'
@@ -79,7 +79,7 @@ class Products extends Component {
       <div>
         <ul className="products-list">
           {products.map((product) => {
-            const itemLink = '/product/' + product.id;
+            //const itemLink = '/product/' + product.id;
             const averageRating = (product.reviews.reduce((a,b) => a + (b["rating"] || 0),0) / product.reviews.length).toFixed(1)
 
             let stars = [1,2,3,4,5].map((index) => {

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import Context from '../utils/context';
-import { Link } from 'react-router-dom';
+//import { Link } from 'react-router-dom';
 import './products.css';
 import * as Sentry from '@sentry/react';
 import { connect } from 'react-redux'
@@ -61,7 +61,7 @@ class ProductsJoin extends Component {
       <div>
         <ul className="products-list">
           {products.map((product) => {
-            const itemLink = '/product/' + product.id;
+            //const itemLink = '/product/' + product.id;
             const averageRating = (product.reviews.reduce((a,b) => a + (b["rating"] || 0),0) / product.reviews.length).toFixed(1)
 
             let stars = [1,2,3,4,5].map((index) => {

--- a/react/src/utils/errors.js
+++ b/react/src/utils/errors.js
@@ -9,6 +9,7 @@ const notAFunctionError = () => {
 const referenceError = () => {
   throw new ReferenceError('undefinedVariable is not defined')
 };
+//eslint-disable-next-line
 const syntaxError = () => eval('foo bar');
 const rangeError = () => {
   throw new RangeError('Parameter must be between 1 and 100');

--- a/react/validate_env.list
+++ b/react/validate_env.list
@@ -1,3 +1,4 @@
+# create-react-app requires all env vars start with REACT_APP_
 REACT_APP_DSN
 REACT_APP_RELEASE   
 REACT_APP_FLASK_BACKEND

--- a/vue/build.sh
+++ b/vue/build.sh
@@ -4,4 +4,6 @@ USAGE="Usage: ./build.sh"
 
 set -e # exit immediately if any command exits with a non-zero status
 
+rm -rf dist
+npm install
 npm run build # defined in 'scripts' in package.json


### PR DESCRIPTION
-  validate `.env` specifically, not exported env vars
-  validate_env for all projects, not just react
-  ability to run `npm start` w/ hot reload without running the entire `deploy.sh`
    - `env.sh` standalone mode
-  set `RELEASE/REACT_APP_RELEASE` in temporary `.env` to fix Flask not sending right release
-  Remove eslint build-time warnings
-  Always do a clean build with `rm -rf build; npm install`

### Testing
`./deploy.sh --env=local react`
`./deploy.sh --env=local react flask`
`./deploy.sh --env=staging react`
```
cd react
../env.sh local npm start
```