### PR TITLE
Selenium Session message capture for All Platforms

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,8 @@ def data_center(request):
 @pytest.fixture(params=desktop_browsers)
 def desktop_web_driver(request, data_center):
 
+    sentry_sdk.set_tag("pytestPlatform", "desktop_web")
+
     test_name = request.node.name
     build_tag = environ.get('BUILD_TAG', "Application-Monitoring-TDA")
 
@@ -112,11 +114,13 @@ def desktop_web_driver(request, data_center):
     browser.execute_script("sauce:job-result={}".format(sauce_result))
     browser.quit()
 
-    # Handler done scenario, send to Sentry job-monitor-application-monitoring
+    # desktop_web tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
     sentry_sdk.capture_message("Selenium Session Done")
 
 @pytest.fixture
 def android_react_native_emu_driver(request, data_center):
+
+    sentry_sdk.set_tag("pytestPlatform", "android_react_native")
 
     username_cap = environ['SAUCE_USERNAME']
     access_key_cap = environ['SAUCE_ACCESS_KEY']
@@ -149,8 +153,13 @@ def android_react_native_emu_driver(request, data_center):
     driver.execute_script("sauce:job-result={}".format(sauce_result))
     driver.quit()
 
+    # android_react_native tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+    sentry_sdk.capture_message("Selenium Session Done")
+
 @pytest.fixture
 def android_emu_driver(request, data_center):
+
+    sentry_sdk.set_tag("pytestPlatform", "android")
 
     username_cap = environ['SAUCE_USERNAME']
     access_key_cap = environ['SAUCE_ACCESS_KEY']
@@ -183,8 +192,13 @@ def android_emu_driver(request, data_center):
     driver.execute_script("sauce:job-result={}".format(sauce_result))
     driver.quit()
 
+    # android tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+    sentry_sdk.capture_message("Selenium Session Done")
+
 @pytest.fixture
 def ios_react_native_sim_driver(request, data_center):
+
+    sentry_sdk.set_tag("pytestPlatform", "ios_react_native")
 
     username_cap = environ['SAUCE_USERNAME']
     access_key_cap = environ['SAUCE_ACCESS_KEY']
@@ -217,8 +231,13 @@ def ios_react_native_sim_driver(request, data_center):
     driver.execute_script("sauce:job-result={}".format(sauce_result))
     driver.quit()
 
+    # ios_react_native tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+    sentry_sdk.capture_message("Selenium Session Done")
+
 @pytest.fixture
 def ios_sim_driver(request, data_center):
+
+    sentry_sdk.set_tag("pytestPlatform", "ios")
 
     username_cap = environ['SAUCE_USERNAME']
     access_key_cap = environ['SAUCE_ACCESS_KEY']
@@ -250,6 +269,9 @@ def ios_sim_driver(request, data_center):
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     driver.execute_script("sauce:job-result={}".format(sauce_result))
     driver.quit()
+
+    # ios tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+    sentry_sdk.capture_message("Selenium Session Done")
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,213 +65,245 @@ def data_center(request):
 @pytest.fixture(params=desktop_browsers)
 def desktop_web_driver(request, data_center):
 
-    sentry_sdk.set_tag("pytestPlatform", "desktop_web")
+    try:
+        sentry_sdk.set_tag("pytestPlatform", "desktop_web")
 
-    test_name = request.node.name
-    build_tag = environ.get('BUILD_TAG', "Application-Monitoring-TDA")
+        test_name = request.node.name
+        build_tag = environ.get('BUILD_TAG', "Application-Monitoring-TDA")
 
-    username = environ['SAUCE_USERNAME']
-    access_key = environ['SAUCE_ACCESS_KEY']
+        username = environ['SAUCE_USERNAME']
+        access_key = environ['SAUCE_ACCESS_KEY']
 
-    if data_center and data_center.lower() == 'eu':
-        selenium_endpoint = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
-    else:
-        selenium_endpoint = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
+        if data_center and data_center.lower() == 'eu':
+            selenium_endpoint = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username, access_key)
+        else:
+            selenium_endpoint = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
 
-    caps = dict()
-    caps.update(request.param)
-    caps['sauce:options'].update({'build': build_tag})
-    caps['sauce:options'].update({'name': test_name})
+        caps = dict()
+        caps.update(request.param)
+        caps['sauce:options'].update({'build': build_tag})
+        caps['sauce:options'].update({'name': test_name})
 
-    browser = webdriver.Remote(
-        command_executor=selenium_endpoint,
-        desired_capabilities=caps,
-        keep_alive=True
-    )
+        browser = webdriver.Remote(
+            command_executor=selenium_endpoint,
+            desired_capabilities=caps,
+            keep_alive=True
+        )
 
-    browser.implicitly_wait(10)
+        browser.implicitly_wait(10)
 
-    sentry_sdk.set_tag("seleniumSessionId", browser.session_id)
+        sentry_sdk.set_tag("seleniumSessionId", browser.session_id)
 
-    # This is specifically for SauceLabs plugin.
-    # In case test fails after selenium session creation having this here will help track it down.
-    if browser is not None:
-        print("SauceOnDemandSessionID={} job-name={}".format(browser.session_id, test_name))
-    else:
-        raise WebDriverException("Never created!")
+        # This is specifically for SauceLabs plugin.
+        # In case test fails after selenium session creation having this here will help track it down.
+        if browser is not None:
+            print("SauceOnDemandSessionID={} job-name={}".format(browser.session_id, test_name))
+        else:
+            raise WebDriverException("Never created!")
 
-    yield browser
+        yield browser
 
-    # Teardown starts here
-    # report results
-    # use the test result to send the pass/fail status to Sauce Labs
-    sauce_result = "failed" if request.node.rep_call.failed else "passed"
+        # Teardown starts here
+        # report results
+        # use the test result to send the pass/fail status to Sauce Labs
+        sauce_result = "failed" if request.node.rep_call.failed else "passed"
 
-    # Handler failure scenario, send to Sentry job-monitor-application-monitoring
-    if sauce_result == "failed":
-        sentry_sdk.capture_message("Sauce Result: %s" % (sauce_result))
+        # Handler failure scenario, send to Sentry job-monitor-application-monitoring
+        if sauce_result == "failed":
+            sentry_sdk.capture_message("Sauce Result: %s" % (sauce_result))
 
-    browser.execute_script("sauce:job-result={}".format(sauce_result))
-    browser.quit()
+        browser.execute_script("sauce:job-result={}".format(sauce_result))
+        browser.quit()
 
-    # desktop_web tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
-    sentry_sdk.capture_message("Selenium Session Done")
+        # desktop_web tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+        sentry_sdk.capture_message("Selenium Session Done")
+    
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
 @pytest.fixture
 def android_react_native_emu_driver(request, data_center):
 
-    sentry_sdk.set_tag("pytestPlatform", "android_react_native")
+    try:
+        sentry_sdk.set_tag("pytestPlatform", "android_react_native")
 
-    username_cap = environ['SAUCE_USERNAME']
-    access_key_cap = environ['SAUCE_ACCESS_KEY']
-    release_version = ReleaseVersion.latest_react_native_github_release()
+        username_cap = environ['SAUCE_USERNAME']
+        access_key_cap = environ['SAUCE_ACCESS_KEY']
+        release_version = ReleaseVersion.latest_react_native_github_release()
 
-    caps = {
-        'username': username_cap,
-        'accessKey': access_key_cap,
-        'deviceName': 'Android GoogleAPI Emulator',
-        'platformVersion': '10.0',
-        'platformName': 'Android',
-        'app': f'https://github.com/sentry-demos/sentry_react_native/releases/download/{release_version}/app-release.apk',
-        'sauce:options': {
-            'appiumVersion': '1.20.2',
-            'build': 'RDC-Android-Python-Best-Practice',
-            'name': request.node.name
-        },
-        'appWaitForLaunch': False
-    }
+        caps = {
+            'username': username_cap,
+            'accessKey': access_key_cap,
+            'deviceName': 'Android GoogleAPI Emulator',
+            'platformVersion': '10.0',
+            'platformName': 'Android',
+            'app': f'https://github.com/sentry-demos/sentry_react_native/releases/download/{release_version}/app-release.apk',
+            'sauce:options': {
+                'appiumVersion': '1.20.2',
+                'build': 'RDC-Android-Python-Best-Practice',
+                'name': request.node.name
+            },
+            'appWaitForLaunch': False
+        }
 
-    if data_center and data_center.lower() == 'eu':
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
-    else:
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        if data_center and data_center.lower() == 'eu':
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        else:
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
-    driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
-    driver.implicitly_wait(20)
-    yield driver
-    sauce_result = "failed" if request.node.rep_call.failed else "passed"
-    driver.execute_script("sauce:job-result={}".format(sauce_result))
-    driver.quit()
+        driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
+        driver.implicitly_wait(20)
 
-    # android_react_native tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
-    sentry_sdk.capture_message("Selenium Session Done")
+        sentry_sdk.set_tag("seleniumSessionId", driver.session_id)
+
+        yield driver
+        sauce_result = "failed" if request.node.rep_call.failed else "passed"
+        driver.execute_script("sauce:job-result={}".format(sauce_result))
+        driver.quit()
+
+        # android_react_native tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+        sentry_sdk.capture_message("Selenium Session Done")
+    
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
 @pytest.fixture
 def android_emu_driver(request, data_center):
 
-    sentry_sdk.set_tag("pytestPlatform", "android")
+    try:
+        sentry_sdk.set_tag("pytestPlatform", "android")
 
-    username_cap = environ['SAUCE_USERNAME']
-    access_key_cap = environ['SAUCE_ACCESS_KEY']
-    release_version = ReleaseVersion.latest_android_github_release()
+        username_cap = environ['SAUCE_USERNAME']
+        access_key_cap = environ['SAUCE_ACCESS_KEY']
+        release_version = ReleaseVersion.latest_android_github_release()
 
-    caps = {
-        'username': username_cap,
-        'accessKey': access_key_cap,
-        'deviceName': 'Android GoogleAPI Emulator',
-        'platformVersion': '10.0',
-        'platformName': 'Android',
-        'app': f'https://github.com/sentry-demos/android/releases/download/{release_version}/app-release.apk',
-        'sauce:options': {
-            'appiumVersion': '1.20.2',
-            'build': 'RDC-Android-Python-Best-Practice',
-            'name': request.node.name
-        },
-        'appWaitForLaunch': False
-    }
+        caps = {
+            'username': username_cap,
+            'accessKey': access_key_cap,
+            'deviceName': 'Android GoogleAPI Emulator',
+            'platformVersion': '10.0',
+            'platformName': 'Android',
+            'app': f'https://github.com/sentry-demos/android/releases/download/{release_version}/app-release.apk',
+            'sauce:options': {
+                'appiumVersion': '1.20.2',
+                'build': 'RDC-Android-Python-Best-Practice',
+                'name': request.node.name
+            },
+            'appWaitForLaunch': False
+        }
 
-    if data_center and data_center.lower() == 'eu':
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
-    else:
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        if data_center and data_center.lower() == 'eu':
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        else:
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
-    driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
-    driver.implicitly_wait(20)
-    yield driver
-    sauce_result = "failed" if request.node.rep_call.failed else "passed"
-    driver.execute_script("sauce:job-result={}".format(sauce_result))
-    driver.quit()
+        driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
+        driver.implicitly_wait(20)
 
-    # android tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
-    sentry_sdk.capture_message("Selenium Session Done")
+        sentry_sdk.set_tag("seleniumSessionId", driver.session_id)
+
+        yield driver
+        sauce_result = "failed" if request.node.rep_call.failed else "passed"
+        driver.execute_script("sauce:job-result={}".format(sauce_result))
+        driver.quit()
+
+        # android tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+        sentry_sdk.capture_message("Selenium Session Done")
+
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
 @pytest.fixture
 def ios_react_native_sim_driver(request, data_center):
 
-    sentry_sdk.set_tag("pytestPlatform", "ios_react_native")
+    try:
+        sentry_sdk.set_tag("pytestPlatform", "ios_react_native")
 
-    username_cap = environ['SAUCE_USERNAME']
-    access_key_cap = environ['SAUCE_ACCESS_KEY']
-    release_version = ReleaseVersion.latest_react_native_github_release()
+        username_cap = environ['SAUCE_USERNAME']
+        access_key_cap = environ['SAUCE_ACCESS_KEY']
+        release_version = ReleaseVersion.latest_react_native_github_release()
 
-    caps = {
-        'username': username_cap,
-        'accessKey': access_key_cap,
-        'appium:deviceName': 'iPhone 11 Simulator',
-        'platformName': 'iOS',
-        'appium:platformVersion': '14.5',
+        caps = {
+            'username': username_cap,
+            'accessKey': access_key_cap,
+            'appium:deviceName': 'iPhone 11 Simulator',
+            'platformName': 'iOS',
+            'appium:platformVersion': '14.5',
 
-        'sauce:options': {
-            'appiumVersion': '1.21.0',
-            'build': 'RDC-iOS-Python-Best-Practice',
-            'name': request.node.name,
-        },
-        'appium:app': f'https://github.com/sentry-demos/sentry_react_native/releases/download/{release_version}/sentry_react_native.app.zip',
-    }
+            'sauce:options': {
+                'appiumVersion': '1.21.0',
+                'build': 'RDC-iOS-Python-Best-Practice',
+                'name': request.node.name,
+            },
+            'appium:app': f'https://github.com/sentry-demos/sentry_react_native/releases/download/{release_version}/sentry_react_native.app.zip',
+        }
 
-    if data_center and data_center.lower() == 'eu':
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
-    else:
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        if data_center and data_center.lower() == 'eu':
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        else:
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
-    driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
-    driver.implicitly_wait(20)
-    yield driver
-    sauce_result = "failed" if request.node.rep_call.failed else "passed"
-    driver.execute_script("sauce:job-result={}".format(sauce_result))
-    driver.quit()
+        driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
+        driver.implicitly_wait(20)
 
-    # ios_react_native tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
-    sentry_sdk.capture_message("Selenium Session Done")
+        sentry_sdk.set_tag("seleniumSessionId", driver.session_id)
+
+        yield driver
+        sauce_result = "failed" if request.node.rep_call.failed else "passed"
+        driver.execute_script("sauce:job-result={}".format(sauce_result))
+        driver.quit()
+
+        # ios_react_native tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+        sentry_sdk.capture_message("Selenium Session Done")
+    
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
 @pytest.fixture
 def ios_sim_driver(request, data_center):
 
-    sentry_sdk.set_tag("pytestPlatform", "ios")
+    try:
+        sentry_sdk.set_tag("pytestPlatform", "ios")
 
-    username_cap = environ['SAUCE_USERNAME']
-    access_key_cap = environ['SAUCE_ACCESS_KEY']
-    release_version = ReleaseVersion.latest_ios_github_release()
+        username_cap = environ['SAUCE_USERNAME']
+        access_key_cap = environ['SAUCE_ACCESS_KEY']
+        release_version = ReleaseVersion.latest_ios_github_release()
 
-    caps = {
-        'username': username_cap,
-        'accessKey': access_key_cap,
-        'appium:deviceName': 'iPhone 11 Simulator',
-        'platformName': 'iOS',
-        'appium:platformVersion': '14.5',
+        caps = {
+            'username': username_cap,
+            'accessKey': access_key_cap,
+            'appium:deviceName': 'iPhone 11 Simulator',
+            'platformName': 'iOS',
+            'appium:platformVersion': '14.5',
 
-        'sauce:options': {
-            'appiumVersion': '1.21.0',
-            'build': 'RDC-iOS-Mobile-Native',
-            'name': request.node.name,
-        },
-        'appium:app': f'https://github.com/sentry-demos/ios/releases/download/{release_version}/EmpowerPlant_release.zip',
-    }
+            'sauce:options': {
+                'appiumVersion': '1.21.0',
+                'build': 'RDC-iOS-Mobile-Native',
+                'name': request.node.name,
+            },
+            'appium:app': f'https://github.com/sentry-demos/ios/releases/download/{release_version}/EmpowerPlant_release.zip',
+        }
 
-    if data_center and data_center.lower() == 'eu':
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
-    else:
-        sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        if data_center and data_center.lower() == 'eu':
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
+        else:
+            sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
-    driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
-    driver.implicitly_wait(20)
-    yield driver
-    sauce_result = "failed" if request.node.rep_call.failed else "passed"
-    driver.execute_script("sauce:job-result={}".format(sauce_result))
-    driver.quit()
+        driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
+        driver.implicitly_wait(20)
 
-    # ios tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
-    sentry_sdk.capture_message("Selenium Session Done")
+        sentry_sdk.set_tag("seleniumSessionId", driver.session_id)
+
+        yield driver
+        sauce_result = "failed" if request.node.rep_call.failed else "passed"
+        driver.execute_script("sauce:job-result={}".format(sauce_result))
+        driver.quit()
+
+        # ios tests finished, send to Sentry job-monitor-application-monitoring, look for tags pytestName, pytestPlatform, seleniumSessionId
+        sentry_sdk.capture_message("Selenium Session Done")
+        
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/tests/desktop_web/test_about_employees.py
+++ b/tests/desktop_web/test_about_employees.py
@@ -5,7 +5,7 @@ import sentry_sdk
 from urllib.parse import urlencode
 
 def test_about_employees(desktop_web_driver):
-    sentry_sdk.set_tag("pytestName", "about_employees")
+    sentry_sdk.set_tag("pytestName", "test_about_employees")
 
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)

--- a/tests/desktop_web/test_about_employees_vue.py
+++ b/tests/desktop_web/test_about_employees_vue.py
@@ -5,8 +5,8 @@ import sentry_sdk
 from urllib.parse import urlencode
 from collections import OrderedDict
 
-def test_about_employees(desktop_web_driver):
-    sentry_sdk.set_tag("pytestName", "vue_test_about_employees")
+def test_about_employees_vue(desktop_web_driver):
+    sentry_sdk.set_tag("pytestName", "test_about_employees_vue")
 
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)

--- a/tests/desktop_web/test_add_to_cart.py
+++ b/tests/desktop_web/test_add_to_cart.py
@@ -67,7 +67,6 @@ def test_add_to_cart(desktop_web_driver):
             except Exception as err:
                 missedButtons = missedButtons + 1
                 sentry_sdk.set_tag("missedButtons", missedButtons)
-                sentry_sdk.set_tag("seleniumSessionId", desktop_web_driver.session_id)
 
                 if err:
                     sentry_sdk.capture_exception(err)

--- a/tests/desktop_web/test_homepage_vue.py
+++ b/tests/desktop_web/test_homepage_vue.py
@@ -6,8 +6,8 @@ from urllib.parse import urlencode
 from collections import OrderedDict
 
 # Note: Not sure why won't pytest find this and run it when I name it 'vue_test_homepage'
-def test_homepage(desktop_web_driver):
-    sentry_sdk.set_tag("pytestName", "vue_test_homepage")
+def test_homepage_vue(desktop_web_driver):
+    sentry_sdk.set_tag("pytestName", "test_homepage_vue")
 
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)

--- a/tests/desktop_web/test_subscribe_vue.py
+++ b/tests/desktop_web/test_subscribe_vue.py
@@ -5,8 +5,8 @@ import sentry_sdk
 from urllib.parse import urlencode
 from collections import OrderedDict
 
-def test_subscribe(desktop_web_driver):
-    sentry_sdk.set_tag("pytestName", "vue_test_subscribe")
+def test_subscribe_vue(desktop_web_driver):
+    sentry_sdk.set_tag("pytestName", "test_subscribe_vue")
 
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)


### PR DESCRIPTION
and custom tags

`pytestName` still in use

I added:
`pytestPlatform` like desktop_web, android_react_native, android, ios

and `try/except` handling around the creation of selenium sessions in `conftest.py` for each pytest.fixture, before each individual test is run.