### PR TITLE
IOS checkout test - DO NOT MERGE

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import sentry_sdk
 from dotenv import load_dotenv
 load_dotenv()
 
-SAUCELABS_PROTOCOL = "http://"
+SAUCELABS_PROTOCOL = "https://"
 DSN = os.getenv("DSN")
 ENVIRONMENT = os.getenv("ENVIRONMENT") or "production"
 
@@ -154,8 +154,8 @@ def android_react_native_emu_driver(request, data_center):
 @pytest.fixture
 def android_emu_driver(request, data_center):
 
-    username_cap = 'sentry-se'
-    access_key_cap = 'e8e07a9f-613f-4d40-b17d-40163098cadb'
+    username = environ['SAUCE_USERNAME']
+    access_key = environ['SAUCE_ACCESS_KEY']
     release_version = ReleaseVersion.latest_android_github_release()
 
     caps = {
@@ -164,7 +164,7 @@ def android_emu_driver(request, data_center):
         'deviceName': 'Android GoogleAPI Emulator',
         'platformVersion': '10.0',
         'platformName': 'Android',
-        'app': f'https://cb05-2607-9880-10c8-72-1484-c603-9388-3439.ngrok.io/app-debug.apk',
+        'app': f'https://github.com/sentry-demos/android/releases/download/{release_version}/app-release.apk',
         'sauce:options': {
             'appiumVersion': '1.20.2',
             'build': 'RDC-Android-Python-Best-Practice',
@@ -197,7 +197,7 @@ def ios_react_native_sim_driver(request, data_center):
         'accessKey': access_key_cap,
         'appium:deviceName': 'iPhone 11 Simulator',
         'platformName': 'iOS',
-        'appium:platformVersion': '15.4',
+        'appium:platformVersion': '14.5',
 
         'sauce:options': {
             'appiumVersion': '1.21.0',
@@ -243,12 +243,6 @@ def ios_sim_driver(request, data_center):
 
         'appium:app': f'/Users/sergiolombana/Documents/saucelabs/EmpowerPlant.app',
     }
-
-    print('NODE NAME')
-    print(request.node.name)
-
-    print('RELEASE')
-    print(release_version)
 
     if data_center and data_center.lower() == 'eu':
         sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,8 +154,8 @@ def android_react_native_emu_driver(request, data_center):
 @pytest.fixture
 def android_emu_driver(request, data_center):
 
-    username = environ['SAUCE_USERNAME']
-    access_key = environ['SAUCE_ACCESS_KEY']
+    username_cap = environ['SAUCE_USERNAME']
+    access_key_cap = environ['SAUCE_ACCESS_KEY']
     release_version = ReleaseVersion.latest_android_github_release()
 
     caps = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import sentry_sdk
 from dotenv import load_dotenv
 load_dotenv()
 
-SAUCELABS_PROTOCOL = "https://"
+SAUCELABS_PROTOCOL = "http://"
 DSN = os.getenv("DSN")
 ENVIRONMENT = os.getenv("ENVIRONMENT") or "production"
 
@@ -23,7 +23,7 @@ import urllib3
 urllib3.disable_warnings()
 
 sentry_sdk.init(
-    dsn="https://9802de20229e4afdaa0d60796cbb44d7@o87286.ingest.sentry.io/5390094",
+    dsn="https://f4726f34778044bba8e826740f0e09ac@o87286.ingest.sentry.io/4504052300578816",
     traces_sample_rate=0,
     environment="dev",
 )
@@ -154,8 +154,8 @@ def android_react_native_emu_driver(request, data_center):
 @pytest.fixture
 def android_emu_driver(request, data_center):
 
-    username_cap = environ['SAUCE_USERNAME']
-    access_key_cap = environ['SAUCE_ACCESS_KEY']
+    username_cap = 'sentry-se'
+    access_key_cap = 'e8e07a9f-613f-4d40-b17d-40163098cadb'
     release_version = ReleaseVersion.latest_android_github_release()
 
     caps = {
@@ -164,7 +164,7 @@ def android_emu_driver(request, data_center):
         'deviceName': 'Android GoogleAPI Emulator',
         'platformVersion': '10.0',
         'platformName': 'Android',
-        'app': f'https://github.com/sentry-demos/android/releases/download/{release_version}/app-release.apk',
+        'app': f'https://cb05-2607-9880-10c8-72-1484-c603-9388-3439.ngrok.io/app-debug.apk',
         'sauce:options': {
             'appiumVersion': '1.20.2',
             'build': 'RDC-Android-Python-Best-Practice',
@@ -197,7 +197,7 @@ def ios_react_native_sim_driver(request, data_center):
         'accessKey': access_key_cap,
         'appium:deviceName': 'iPhone 11 Simulator',
         'platformName': 'iOS',
-        'appium:platformVersion': '14.5',
+        'appium:platformVersion': '15.4',
 
         'sauce:options': {
             'appiumVersion': '1.21.0',
@@ -221,9 +221,8 @@ def ios_react_native_sim_driver(request, data_center):
 
 @pytest.fixture
 def ios_sim_driver(request, data_center):
-
-    username_cap = environ['SAUCE_USERNAME']
-    access_key_cap = environ['SAUCE_ACCESS_KEY']
+    username_cap = 'sentry-se'
+    access_key_cap = 'e8e07a9f-613f-4d40-b17d-40163098cadb'
     release_version = ReleaseVersion.latest_ios_github_release()
 
     caps = {
@@ -232,14 +231,26 @@ def ios_sim_driver(request, data_center):
         'appium:deviceName': 'iPhone 11 Simulator',
         'platformName': 'iOS',
         'appium:platformVersion': '14.5',
+        #'udid':'77623AAD-F7EF-4E33-8D57-DABDC8541DE6',
+        #"wdaStartupRetries": "4",
+        #"iosInstallPause": "8000",
+        #"wdaStartupRetryInterval": "20000",
+        "appium:usePrebuiltWDA": "true",
 
         'sauce:options': {
             'appiumVersion': '1.21.0',
             'build': 'RDC-iOS-Mobile-Native',
             'name': request.node.name,
         },
-        'appium:app': f'https://github.com/sentry-demos/ios/releases/download/{release_version}/EmpowerPlant_release.zip',
+
+        'appium:app': f'https://2776-2607-9880-10c8-72-8004-f784-267e-6230.ngrok.io/EmpowerPlant_0.0.2.app',
     }
+
+    print('NODE NAME')
+    print(request.node.name)
+
+    print('RELEASE')
+    print(release_version)
 
     if data_center and data_center.lower() == 'eu':
         sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.eu-central-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
@@ -249,8 +260,11 @@ def ios_sim_driver(request, data_center):
     driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
     driver.implicitly_wait(20)
     yield driver
-    sauce_result = "failed" if request.node.rep_call.failed else "passed"
-    driver.execute_script("sauce:job-result={}".format(sauce_result))
+
+    #sauce_result = "passed"
+    #driver.execute_script("sauce:job-result='passed'")
+    #driver.execute_script("sauce:job-result={}".format(sauce_result))
+
     driver.quit()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,8 +221,9 @@ def ios_react_native_sim_driver(request, data_center):
 
 @pytest.fixture
 def ios_sim_driver(request, data_center):
-    username_cap = 'sentry-se'
-    access_key_cap = 'e8e07a9f-613f-4d40-b17d-40163098cadb'
+
+    username_cap = environ['SAUCE_USERNAME']
+    access_key_cap = environ['SAUCE_ACCESS_KEY']
     release_version = ReleaseVersion.latest_ios_github_release()
 
     caps = {
@@ -230,12 +231,9 @@ def ios_sim_driver(request, data_center):
         'accessKey': access_key_cap,
         'appium:deviceName': 'iPhone 11 Simulator',
         'platformName': 'iOS',
-        'appium:platformVersion': '14.5',
-        #'udid':'77623AAD-F7EF-4E33-8D57-DABDC8541DE6',
-        #"wdaStartupRetries": "4",
-        #"iosInstallPause": "8000",
-        #"wdaStartupRetryInterval": "20000",
-        "appium:usePrebuiltWDA": "true",
+        'appium:platformVersion': '16.1',
+        'udid':'157FB6DB-B28A-4BC1-8181-1524B31CE022',
+        "appium:usePrebuiltWDA": "false",
 
         'sauce:options': {
             'appiumVersion': '1.21.0',
@@ -243,7 +241,7 @@ def ios_sim_driver(request, data_center):
             'name': request.node.name,
         },
 
-        'appium:app': f'https://2776-2607-9880-10c8-72-8004-f784-267e-6230.ngrok.io/EmpowerPlant_0.0.2.app',
+        'appium:app': f'/Users/sergiolombana/Documents/saucelabs/EmpowerPlant.app',
     }
 
     print('NODE NAME')
@@ -257,7 +255,7 @@ def ios_sim_driver(request, data_center):
     else:
         sauce_url = SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username_cap, access_key_cap)
 
-    driver = appiumdriver.Remote(sauce_url, desired_capabilities=caps)
+    driver = appiumdriver.Remote('http://0.0.0.0:4723/wd/hub', desired_capabilities=caps)
     driver.implicitly_wait(20)
     yield driver
 

--- a/tests/mobile_native/ios/test_checkout_ios.py
+++ b/tests/mobile_native/ios/test_checkout_ios.py
@@ -4,14 +4,14 @@ def test_checkout_ios(ios_sim_driver):
     sentry_sdk.set_tag("pytestName", "test_checkout_ios")
 
     try:
-        first_item = ios_sim_driver.find_element_by_xpath('//XCUIElementTypeApplication[@name="EmpowerPlant"]/XCUIElementTypeWindow/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeTable[1]/XCUIElementTypeCell[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther')
-        first_item.click()
-        first_item.click()
-        first_item.click()
-        first_item.click()
+        first_item = ios_sim_driver.find_elements(by="xpath", value='//XCUIElementTypeApplication[@name="EmpowerPlant"]/XCUIElementTypeWindow/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeTable[1]/XCUIElementTypeCell[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther')
+        first_item[0].click()
+        first_item[0].click()
+        first_item[0].click()
+        first_item[0].click()
 
-        ios_sim_driver.find_element_by_accessibility_id("Cart").click()
-        ios_sim_driver.find_element_by_accessibility_id("Purchase").click()
+        ios_sim_driver.find_elements(by="accessibility id", value="Cart")[0].click()
+        ios_sim_driver.find_elements(by="accessibility id", value="Purchase")[0].click()
 
         # wait for confirmation of purchase? (currently nothing happens)
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -18,7 +18,7 @@ py==1.10.0
 pyparsing==2.4.7
 pytest-forked==1.3.0
 pytest-xdist==2.2.1
-pytest==6.0.0
+pytest==6.2.5
 pyyaml==5.4.1
 requests==2.25.1
 robotframework-appiumlibrary==1.5.0.7

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 -i https://pypi.org/simple
 apipkg==1.5
-appium-python-client==1.3.0
+appium-python-client==2.7.1
 attrs==20.3.0
 certifi==2020.12.5
 chardet==4.0.0
@@ -28,7 +28,7 @@ robotframework-seleniumlibrary==5.1.3
 robotframework==4.0.1
 saucebindings==1.0.0
 sauceclient==1.0.0
-selenium==3.141.0
+selenium==4.1
 six==1.15.0
 testobject==1.0.0.post1
 toml==0.10.2


### PR DESCRIPTION
This pull request aims to fix the Saucelabs error when running the `test_checkout_ios.py` test:
Currently, the test is not running on Saucelabs and it is not clear to me where in the process the test is failing.
However, I was able to generate a running copy of the test by running the Appium server locally and generating my own build of the IOS application from release (0.0.3)[https://github.com/sentry-demos/ios/releases/tag/0.0.3]. To make this work, I followed these steps:

- Updated the packages on `requirements.txt` . Remember to run pip install -r requirements.txt after cloning this copy
- Run Appium server locally from the Appium Server GUI (link)[https://github.com/appium/appium-desktop]. Make sure that the host is set to 0.0.0.0 and port to 4723
- Have a simulator running with `WebDriverAgent` installed in it. (guide)[https://www.mutuallyhuman.com/blog/webdriveragent-getting-started-with-automated-ios-testing/] (Follow the guide up to step 3 and then run the Appium server)
- Make sure that the simulator name and version is the same as the one specified on `ios_sim_driver`
- Run `py.test -s -n 4 mobile_native/ios/test_checkout_ios.py`
- You will see how the Appium server runs the test in real time