### PR TITLE
Fixes Express DB Config and Broken Boolean Evaluation of Headers

### DIFF
--- a/express/db.js
+++ b/express/db.js
@@ -142,6 +142,9 @@ function openDBConnection() {
 
   let host
   if (process.env.EXPRESS_ENV === 'test') {
+    // The cloud sql instance connection
+    // name doesn't work locally, but the
+    // public IP of the instance does.
     host = process.env.HOST
   } else {
     host = '/cloudsql/' + process.env.CLOUD_SQL_CONNECTION_NAME

--- a/express/db.js
+++ b/express/db.js
@@ -1,6 +1,5 @@
 require('dotenv').config();
 const Sentry = require('@sentry/node');
-// const { Console } = require('@sentry/node/dist/integrations');
 
 // Knex is the database query builder used in the GCP docs, which
 // is why we are using it here. See docs:

--- a/express/server.js
+++ b/express/server.js
@@ -25,19 +25,20 @@ const cors = require('cors');
 var headers = {}
 const sentryEventContext = function(req, res, next) {
   const se = req.headers.se;
-  if(!['undefined'].includes(se)) {
+
+  if(se !== undefined) {
     Sentry.setTag("se", se);
     headers["se"]=se
   }
 
   const customerType = req.headers.customertype;
-  if(!['undefined'].includes(customerType)) {
+  if(customerType !== undefined) {
     Sentry.setTag("customerType", customerType);
     headers["customerType"]=customerType
   }
 
   const email = req.headers.email;
-  if(!['undefined'].includes(email)) {
+  if(email !== undefined) {
     Sentry.setUser({ 'email': email })
     headers["email"]=email
   }
@@ -118,6 +119,7 @@ app.get('/products', async (req, res) => {
       .getScope()
       .getTransaction();
     let span = transaction.startChild({ op: '/products.get_products', description: 'function' });
+
     const products = await DB.getProducts();
     span.finish();
 

--- a/flask/db.py
+++ b/flask/db.py
@@ -50,7 +50,7 @@ def get_products():
         products = connection.execute(
             "SELECT *, pg_sleep(%s) FROM products" % (n)
         ).fetchall()
-        
+
         for product in products:
             query = text("SELECT *, pg_sleep(0.0625) FROM reviews WHERE productId = :x")
             reviews = connection.execute(query, x=product.id).fetchall()


### PR DESCRIPTION
PUBLIC_CLOUD_IP is not a var in config, but HOST already is (it's the IP address that PUBLIC_CLOUD_IP was trying to refer to) and HOST is already available in config.


Angelo and I found that if you pass `undefined` as the value (sometimes the calling Frontend doesn't pass it, or you're pasting the URL into the Browser URL bar and not setting headers), then this still evaluates to true, and it sets `customerType:undefined` and so express's /products's http call to Ruby fails on 
```
Server process(es) are running. Press Ctrl+C to terminate...
> /products headers { se: undefined, customerType: undefined, email: undefined }
TypeError [ERR_HTTP_INVALID_HEADER_VALUE]: Invalid value "undefined" for header "se"
    at ClientRequest.setHeader (_http_outgoing.js:536:3)
    at new ClientRequest (_http_client.js:249:14)
    at Object.request (https.js:310:10)
```
^ notice the headers are still undefined, that is a result of the following code:

```
  if(!['undefined'].includes(customerType)) {
    Sentry.setTag("customerType", customerType);
    headers["customerType"]=customerType
  }
```
^ This is poor readability, the boolean evaluation, "if not undefined includes customerType", is confusing.

So far it's fixed by, "if customerType is not undefined"
```
  if(customerType !== undefined) {
    Sentry.setTag("customerType", customerType);
    headers["customerType"]=customerType
  }
```
^ no longer sets customerType:undefined. Rather, it skips setting the header altogether, if the value coming in is undefined.

## Testing
[trace link](https://sentry.io/organizations/testorg-az/performance/trace/2d03376df42b43a7a55b5890ce21989a/?pageEnd=2022-11-11T02%3A57%3A58.862&pageStart=2022-11-10T02%3A57%3A48.039) (includes Frontend React app transactions, headers)

Headers work when present as well as not provided.

Backend products txn in Express looks fine
Haven't tested on Staging, but neither has the new deploy.sh been tested for Staging.
No way this will reach production if it doesn't work on Staging first.
