### PR TITLE
Optimize string literal concatenation by eliminating operand redundancy

### DIFF
--- a/react/src/components/Checkout.js
+++ b/react/src/components/Checkout.js
@@ -65,7 +65,7 @@ function Checkout(props) {
 
     let response = await checkout(cart)
     if (!response.ok) {
-      Sentry.captureException(new Error(response.status + " - " + (response.statusText || "Internal Server Error") + ""))
+      Sentry.captureException(new Error(response.status + " - " + (response.statusText || "Internal Server Error")))
     }
 
     setLoading(false)


### PR DESCRIPTION
This change attempts to optimize string literal concatenation during API request error reporting which has been notoriously for causing widespread client-side performance issues resulting in loss of revenue, appetite and migraines among our product leadership. We attempt to fix it in this PR by (1) reducing the redundancy in the number of operands and (2) using a more optimal method of concatenation.

If we were to believe [Peter Riesz](https://stackoverflow.com/users/1003150/peter-riesz)'s [benchmark from 2021](https://stackoverflow.com/questions/16696632/most-efficient-way-to-concatenate-strings-in-javascript?answertab=trending#tab-top) that tested both Chrome 86.0 and Node.js, `+` and `+=` are faster than `Array.prototype.join()` by a whopping factor of 3x, and are closely followed by concatenation using template literal substitution (`${}`) that's almost as fast.

That said above benchmark uses:

- Concatenates 5 string at a time in a loop. Different scenario may produce different results as e.g. numbers for `join` include repeated array allocation.
- No data availiable for Firefox or Safari. (TODO)
- As [JSmart523](https://stackoverflow.com/users/7158380/jsmart523) noted, garbage collection may be playing a role here because the first test enjoys a huge advantage regardless of which you choose as first.


However, according to a [2020 Stackoverflow answer](https://stackoverflow.com/questions/7299010/why-is-string-concatenation-faster-than-array-join) by Manohar Reddy Poreddy:

> Chrome: Array `join` (`Array.prototype.join()`) is almost 2 times faster is String concat + See: https://stackoverflow.com/a/54970240/984471
> 
> As a note:
> 
> Array `join` is better if you have large strings
> If we need generate several small strings in final output, it is better to go with string concat `+`, as otherwise going with Array will need several Array to String conversions at the end which is performance overload.

(In reality this is just a demo PR to create a nice-looking example pull request for a suspect commit. The change itself simply reverts a previous meaningless change, 776bf7422a51b393c969a28931d7ab81b6ac604b,  to the line where we report /checkout 500. That change in turn was used to test new improved suspect commits when they were just introduced.)