### PR TITLE
CODEOWNERS: update with @thinkocapo and @realkosty

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,8 @@
-* @cstavitsky
-react/ @cstavitsky
-react/src/ @cstavitsky
-react/src/components/ @cstavitsky
-/react/ @sdzhong
+* @cstavitsky 
+/* @realkosty
+/env-config/ @realkosty
+/bin/ @realkosty
+/react/ @sdzhong @thinkocapo @realkosty
 /react/src/ @sdzhong
 /react/src/components/ @sdzhong
-flask/ @cstavitsky
 /flask/ @sdzhong


### PR DESCRIPTION
Besides adding @thinkocapo and @realkosty as owners for /react
removed "react" entries without leading /, not sure why we have them - they make no difference