### PR TITLE
[react] Trends: attempt #2

### DIFF
--- a/react/src/components/About.js
+++ b/react/src/components/About.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import slugify from '../utils/slugify';
 import * as Sentry from '@sentry/react';
 import './about.css';
-import { isOddReleaseWeek, sleep } from "../utils/time"
+import { isOddReleaseWeek, busy_sleep } from "../utils/time"
 
 import Jane from './employees/jane';
 import Lily from './employees/lily';
@@ -15,6 +15,15 @@ import Noah from './employees/noah';
 const employees = [Jane, Lily, Keith, Mason, Emma, Noah];
 
 class About extends Component {
+  
+  constructor() {
+    super();
+    // must be inside the constructor to affect LCP, if in componentDidMount() only affects duration
+    if (!isOddReleaseWeek()) {
+      // can't have async sleep in a constructor
+      busy_sleep(Math.random(25) + 100);
+    }
+  }
 
   async componentDidMount() {
     let se, customerType, email
@@ -22,10 +31,6 @@ class About extends Component {
       [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
       email = scope._user.email
     });
-
-    if (!isOddReleaseWeek()) {
-      await sleep(Math.random(25) + 100);
-    }
 
     // Http requests to make in parallel, so the Transaction has more Spans
     let request1 = fetch(this.props.backend + "/api", {

--- a/react/src/components/Organization.js
+++ b/react/src/components/Organization.js
@@ -2,8 +2,19 @@ import { Component } from 'react';
 import logo from '../assets/logo.svg';
 import './Organization.css';
 import * as Sentry from '@sentry/react';
+import {isOddReleaseWeek, busy_sleep } from "../utils/time"
 
 class Organization extends Component {
+
+  constructor() {
+    super();
+    // must be inside the constructor to affect LCP, if in componentDidMount() only affects duration
+    if (isOddReleaseWeek()) {
+      // can't have async sleep in a constructor
+      busy_sleep(Math.random(40) + 150);
+    }
+  }
+
   render() {
     return (
       <div className="App">

--- a/react/src/components/ProductsJoin.js
+++ b/react/src/components/ProductsJoin.js
@@ -6,7 +6,6 @@ import { connect } from 'react-redux'
 import { setProducts, addProduct } from '../actions'
 import Loader from "react-loader-spinner";
 import ProductCard from './ProductCard'
-import {isOddReleaseWeek, sleep } from "../utils/time"
 
 class ProductsJoin extends Component {
   static contextType = Context;
@@ -18,10 +17,6 @@ class ProductsJoin extends Component {
       [ se, customerType ] = [scope._tags.se, scope._tags.customerType ]
       email = scope._user.email
     });
-
-    if (isOddReleaseWeek()) {
-      await sleep(Math.random(40) + 150);
-    }
 
     let result = await fetch(this.props.backend + "/products-join", {
       method: "GET",


### PR DESCRIPTION
Switch to using `/organization` instead of `/products-join` (in addition to `/about`) for trends to avoid accidentally interfering with `/products-join`.

Move sleep from  `componentDidMount()` into `constructor()` in order to affect LCP instead of duration.

Right now LCP is not being captured because of transaction being cut short bug, so can't test it. Although we we can already make the observation that `ui.long-task` is not happening in `/organization`. This may not be a problem as long as it eventually contributes to LCP, although is a bit of a mystery.

### Related PRs
https://github.com/sentry-demos/application-monitoring/pull/107
https://github.com/sentry-demos/application-monitoring/pull/124

### Testing
[/about 1](https://sentry.io/organizations/kosty-org/performance/am-test:0edface1b1b1447c850a72650afc5a50/?project=4504198901334016&query=transaction.duration%3A%3C15m+transaction.op%3Apageload&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Fabout&unselectedSeries=p100%28%29)
[/about 2](https://sentry.io/organizations/kosty-org/performance/am-test:0b9806ed482541ecb6b7f6905a8fb090/?project=4504198901334016&query=transaction.duration%3A%3C15m&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Fabout&unselectedSeries=p100%28%29)
[/organization 1](https://sentry.io/organizations/kosty-org/performance/am-test:555ac7c24fc94862adfdeed4f5bdf529/?project=4504198901334016&query=id%3A555ac7c24fc94862adfdeed4f5bdf529&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Forganization&unselectedSeries=p100%28%29)
[/organization 2](https://sentry.io/organizations/kosty-org/performance/am-test:46b4bfbb496d47b888ef096cddf08b61/?project=4504198901334016&query=transaction.duration%3A%3C15m+transaction.op%3Apageload&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Forganization&unselectedSeries=p100%28%29)
[/organization 3](https://sentry.io/organizations/kosty-org/performance/am-test:56861dbc09c5441d87e55085d0bb521a/?project=4504198901334016&query=&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Forganization&unselectedSeries=p100%28%29)
[/organization 4](https://sentry.io/organizations/kosty-org/performance/am-test:dac2c88c8357481b9d595e4fad3d69b3/?project=4504198901334016&query=&referrer=performance-transaction-summary&statsPeriod=24h&transaction=%2Forganization&unselectedSeries=p100%28%29)