### PR TITLE
Adding HTTP error test

### DIFF
--- a/tests/mobile_native/android/test_httperror_android.py
+++ b/tests/mobile_native/android/test_httperror_android.py
@@ -1,0 +1,19 @@
+import time
+import sentry_sdk
+
+# Automatically capture HTTP Errors with range (400 - 599) status codes
+def test_httperror_android(android_emu_driver):
+    sentry_sdk.set_tag("pytestName", "test_httperror_android")
+
+    try:
+        # navigate to list app
+        android_emu_driver.find_element_by_accessibility_id('More').click()
+        android_emu_driver.find_element_by_xpath('/hierarchy/android.widget.FrameLayout/android.widget.FrameLayout/android.widget.ListView/android.widget.LinearLayout/android.widget.LinearLayout').click()
+
+        # swipe down to have the HTTP Error button in the frame
+        android_emu_driver.swipe(start_x=0, start_y=1100, end_x=0, end_y=500, duration=800)
+        # HTTP Error button
+        android_emu_driver.find_element_by_id('com.example.vu.android:id/error_404').click()
+
+    except Exception as err:
+        sentry_sdk.capture_exception(err)


### PR DESCRIPTION
## Type of Change


[ ] Bugfix
[ ] New Feature
[x] Enhancement
[ ] Refactoring

## Description

Adding test for Android HTTP Errors feature on our android demo that was added on this [pull request](https://github.com/sentry-demos/android/pull/48)

## Testing


`test_httperror_android`
- [saucelabs test](https://app.saucelabs.com/tests/c652035bb6354dd78b72b02140714a32)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3779806734/?project=6749210&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h)