### PR TITLE
[deploy] Update bin/verify_latest_code.sh to use application-monitoring-config

### DIFF
--- a/bin/source_diff_upstream.sh
+++ b/bin/source_diff_upstream.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
 
+set -e
+
 # Outputs diff --stat between the current working tree and master branch of
 # sentry-demos/application-monitoring
 
 UPSTREAM_BRANCH="master"
-UPSTREAM_URL="git@github.com:sentry-demos/application-monitoring-deploy.git"
-ALT_UPSTREAM_URL="https://github.com/sentry-demos/application-monitoring-deploy.git"
+UPSTREAM_URL="git@github.com:sentry-demos/application-monitoring.git"
+CONFIG_BRANCH="main"
+CONFIG_URL="git@github.com:sentry-demos/application-monitoring-config.git"
 
-remote=$(git remote -v | grep $UPSTREAM_URL | head -1 | cut -f 1)
-if [ "$remote" == "" ]; then
-  remote=$(git remote -v | grep $ALT_UPSTREAM_URL | head -1 | cut -f 1)
-fi
-if [ "$remote" == "" ]; then
-  remote="deploy"
-  git remote add $remote $UPSTREAM_URL >/dev/null
+upstream_remote=$(git remote -v | grep $UPSTREAM_URL | head -1 | cut -f 1)
+if [ "$upstream_remote" == "" ]; then
+  upstream_remote="deploy-upstream"
+  git remote add $upstream_remote $UPSTREAM_URL >/dev/null
 fi
 
-git fetch $remote >/dev/null
+config_remote=$(git remote -v | grep $CONFIG_URL | head -1 | cut -f 1)
+if [ "$config_remote" == "" ]; then
+  config_remote="deploy-config"
+  git remote add $config_remote $CONFIG_URL >/dev/null
+fi
 
-git diff --stat $remote/$UPSTREAM_BRANCH -- ':!.github/workflows/auto-deploy.yml' ':!env-config/*.env'
-git diff --stat $remote/$UPSTREAM_BRANCH:env-config/production.env env-config/production.env
+git fetch $upstream_remote >/dev/null
+git fetch $config_remote >/dev/null
+
+git diff --stat $upstream_remote/$UPSTREAM_BRANCH -- ':!env-config/*.env'
+git diff --stat $config_remote/$CONFIG_BRANCH:production.env env-config/production.env

--- a/bin/verify_latest_code.sh
+++ b/bin/verify_latest_code.sh
@@ -7,7 +7,7 @@ diff="$(source_diff_upstream.sh)"
 if [ "$diff" != "" ]; then
     echo "You are about to do a deployment to production, but current code is different from HEAD at
     sentry-demos/application-monitoring AND/OR your production.env is different from production.env in 
-    sentry-demos/application-monitoring-deploy:"
+    sentry-demos/application-monitoring-config:"
     MAX_DIFF_LINES="7"
     difflines="$(echo "$diff" | wc -l)"
     diff="$(echo -n "$diff" | head -$MAX_DIFF_LINES)"


### PR DESCRIPTION
Deprecating `application-monitoring-deploy` broke `bin/verify_latest_code.sh`. This change fixes it.

Not tested in GH Actions environment, only locally, hopefully works.

## Testing
(as part of deploying another change)
```
./deploy.sh --env=production express flask laravel spring-boot aspnetcore
```