### PR TITLE
Session Replay for react (sdk v7.29.0 w/ Replay migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is a multi-language/framework project that implements Empower Plant web app
 
 ## Features
 - Error Monitoring...Performance Monitoring...Release Health...
-- BrowserTracing (Performance)  
+- BrowserTracing (Performance)
+- Session Replay  
 - Sentry.Profiler (class components)  
 - Sentry.withSentryRouting(Route); (react-router)  
 - FlaskIntegration, SqlAlchemyIntegration

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -53,6 +53,7 @@ Sentry.init({
   release: RELEASE,
   environment: ENVIRONMENT,
   tracesSampleRate: 1.0,
+  replaysSessionSampleRate: 1.0,
   debug: true,
   integrations: [
     new Integrations.BrowserTracing({
@@ -80,6 +81,10 @@ Sentry.init({
         };
       },
     }),
+    new Sentry.Replay({
+      // Additional configuration goes in here
+      // replaysSessionSampleRate and replaysOnErrorSampleRate is now a top-level SDK option
+    })
   ],
   beforeSend(event, hint) {
     // Parse from tags because src/index.js already set it there. Once there are React route changes, it is no longer in the URL bar


### PR DESCRIPTION
Old closed PR: https://github.com/sentry-demos/application-monitoring/pull/130/files
Migration GitHub instruction: https://github.com/getsentry/sentry-javascript/blob/master/packages/replay/MIGRATION.md
New docs: https://docs.sentry.io/platforms/javascript/session-replay/

## Testing
```
./deploy.sh --env=replay react
```
https://sentry.io/organizations/testorg-az/issues/3885985697/events/7c584b89b63047e5b9048507dcd31d33/?project=4504318060658688
https://sentry.io/organizations/testorg-az/replays/replay-application-monitoring-react:15069e3f67f8461e8ccc8cee202cdba5/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Fevents%2F%3AeventId%2F&t=48&t_main=console