### PR TITLE
[tda] Make list of backends and SE tag configurable in one place

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from os import environ
 import os
 import release_version_manager as ReleaseVersion
+import random
 
 from selenium import webdriver
 from appium import webdriver as appiumdriver
@@ -15,6 +16,15 @@ load_dotenv()
 SAUCELABS_PROTOCOL = "https://"
 DSN = os.getenv("DSN")
 ENVIRONMENT = os.getenv("ENVIRONMENT") or "production"
+
+def pytest_configure():
+    pytest.SE_TAG=os.getenv("SE_TAG") or "tda"
+    def random_backend(exclude=[]):
+        ALL_BACKENDS=['flask','express','springboot', 'ruby', 'laravel']
+        exclude = [exclude] if isinstance(exclude, str) else exclude
+        backends = list(set(ALL_BACKENDS) - set(exclude))
+        return random.sample(backends, 1)[0]
+    pytest.random_backend = random_backend
 
 print("ENV", ENVIRONMENT)
 print("DSN", DSN)

--- a/tests/desktop_web/test_about_employees.py
+++ b/tests/desktop_web/test_about_employees.py
@@ -2,6 +2,7 @@ import time
 import yaml
 import random
 import sentry_sdk
+import pytest
 from urllib.parse import urlencode
 
 def test_about_employees(desktop_web_driver):
@@ -18,8 +19,8 @@ def test_about_employees(desktop_web_driver):
         # You can filter by se:tda in Sentry's UI as this will get set as a tag
         url = ""
         query_string = {
-            'se': 'tda',
-            'backend': random.sample(['flask','express','springboot', 'ruby', 'laravel'], 1)[0]
+            'se': pytest.SE_TAG,
+            'backend': pytest.random_backend()
         }
         url = endpoint_about + '?' + urlencode(query_string)
 

--- a/tests/desktop_web/test_add_to_cart.py
+++ b/tests/desktop_web/test_add_to_cart.py
@@ -2,6 +2,7 @@ import time
 import yaml
 import random
 import sentry_sdk
+import pytest
 from urllib.parse import urlencode
 
 def test_add_to_cart(desktop_web_driver):
@@ -22,9 +23,9 @@ def test_add_to_cart(desktop_web_driver):
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                'se': 'tda',
+                'se': pytest.SE_TAG,
                 # 'ruby' /products /checkout endpoints not available yet
-                'backend': random.sample(['flask', 'express', 'springboot', 'laravel'], 1)[0]
+                'backend': pytest.random_backend(exclude='ruby')
             }
             url = endpoint_products + '?' + urlencode(query_string)
 

--- a/tests/desktop_web/test_add_to_cart_join.py
+++ b/tests/desktop_web/test_add_to_cart_join.py
@@ -2,6 +2,7 @@ import time
 import yaml
 import random
 import sentry_sdk
+import pytest
 from urllib.parse import urlencode
 
 def test_add_to_cart_join(desktop_web_driver):
@@ -20,9 +21,9 @@ def test_add_to_cart_join(desktop_web_driver):
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = { 
-                'se': 'tda',
+                'se': pytest.SE_TAG,
                 # 'ruby' /products /checkout endpoints not available yet
-                'backend': random.sample(['flask','express','springboot'], 1)[0]
+                'backend': pytest.random_backend(exclude=['ruby', 'laravel'])
             }
             url = endpoint_products_join + '?' + urlencode(query_string)
 

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -2,6 +2,7 @@ import time
 import yaml
 import random
 import sentry_sdk
+import pytest
 from urllib.parse import urlencode
 from collections import OrderedDict
 from datetime import datetime
@@ -42,8 +43,8 @@ def test_homepage(desktop_web_driver):
             # and causes the page to periodically crash, for Release Health
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                'se': 'tda',
-                'backend': random.sample(['flask','express','springboot', 'ruby', 'laravel'], 1)[0],
+                'se': pytest.SE_TAG,
+                'backend': pytest.random_backend(),
                 'crash': "%s" % (n)
             }
             url = endpoint + '?' + urlencode(query_string)

--- a/tests/desktop_web/test_organization.py
+++ b/tests/desktop_web/test_organization.py
@@ -1,6 +1,7 @@
 import time
 import yaml
 import random
+import pytest
 import sentry_sdk
 from urllib.parse import urlencode
 
@@ -18,7 +19,7 @@ def test_organization(desktop_web_driver):
         # You can filter by se:tda in Sentry's UI as this will get set as a tag
         url = ""
         query_string = { 
-            'se': 'tda',
+            'se': pytest.SE_TAG,
         }
         url = endpoint_organization + '?' + urlencode(query_string)
 


### PR DESCRIPTION
### Testing
```
SE_TAG=tda2 py.test -n 1 desktop_web
```
32 passed