### PR TITLE
[tda] Broad improvements: un-hardcoding configuration, better error reporting, etc.

### DIFF
--- a/tests/desktop_web.sh
+++ b/tests/desktop_web.sh
@@ -1,1 +1,1 @@
-while true; do clear && pytest -s -n 4 desktop_web; done
+while true; do clear && SE_TAG=tda BATCH_SIZE=random_20 pytest -s -n 4 desktop_web; done

--- a/tests/desktop_web/test_about_employees.py
+++ b/tests/desktop_web/test_about_employees.py
@@ -26,7 +26,7 @@ def test_about_employees(desktop_web_driver):
 
         employees = ["Jane Schmidt", "Lily Chan", "Keith Ryan", "Mason Kim", "Emma Garcia", "Noah Miller"]
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
 
             desktop_web_driver.get(url)
 

--- a/tests/desktop_web/test_about_employees_vue.py
+++ b/tests/desktop_web/test_about_employees_vue.py
@@ -1,5 +1,6 @@
 import time
 import yaml
+import pytest
 import random
 import sentry_sdk
 from urllib.parse import urlencode
@@ -18,7 +19,7 @@ def test_about_employees_vue(desktop_web_driver):
 
         sentry_sdk.set_tag("endpoint", endpoint)
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
             # TODO in application-monitoring/vue repo
             # should be able to click each employee and it navigates to an /:employee page
             # this demonstrates parameterized transactions in Vue

--- a/tests/desktop_web/test_add_to_cart.py
+++ b/tests/desktop_web/test_add_to_cart.py
@@ -19,7 +19,7 @@ def test_add_to_cart(desktop_web_driver):
 
         missedButtons = 0
 
-        for i in range(random.randrange(20)):
+        for i in range(10):
             # Ensures a different backend endpoint gets picked each time
             url = ""
             # TODO make a query_string builder function for sharing this across tests

--- a/tests/desktop_web/test_add_to_cart_join.py
+++ b/tests/desktop_web/test_add_to_cart_join.py
@@ -16,7 +16,7 @@ def test_add_to_cart_join(desktop_web_driver):
         endpoint_products_join = endpoint + "/products-join"
         sentry_sdk.set_tag("endpoint", endpoint_products_join)
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
             # Ensures a different backend endpoint gets picked each time
             url = ""
             # TODO make a query_string builder function for sharing this across tests

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -35,7 +35,7 @@ def test_homepage(desktop_web_driver):
     for endpoint in endpoints:
         sentry_sdk.set_tag("endpoint", endpoint)
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
             # Randomize the Failure Rate between 1% and 20% or 40%, depending what week it is. Returns values like 0.02, 0.14, 0.37
             n = random.uniform(0.01, upper_bound)
 

--- a/tests/desktop_web/test_homepage_vue.py
+++ b/tests/desktop_web/test_homepage_vue.py
@@ -1,5 +1,6 @@
 import time
 import yaml
+import pytest
 import random
 import sentry_sdk
 from urllib.parse import urlencode
@@ -21,7 +22,7 @@ def test_homepage_vue(desktop_web_driver):
 
         missedButtons = 0
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
             # TODO in application-monitoring/vue repo
             # querystring support for 'se' and 'backend' tags
             

--- a/tests/desktop_web/test_organization.py
+++ b/tests/desktop_web/test_organization.py
@@ -23,7 +23,7 @@ def test_organization(desktop_web_driver):
         }
         url = endpoint_organization + '?' + urlencode(query_string)
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
         
             desktop_web_driver.get(url)
 

--- a/tests/desktop_web/test_subscribe_vue.py
+++ b/tests/desktop_web/test_subscribe_vue.py
@@ -1,5 +1,6 @@
 import time
 import yaml
+import pytest
 import random
 import sentry_sdk
 from urllib.parse import urlencode
@@ -19,7 +20,7 @@ def test_subscribe_vue(desktop_web_driver):
 
         sentry_sdk.set_tag("endpoint", endpoint)
 
-        for i in range(random.randrange(20)):
+        for i in range(pytest.batch_size()):
 
             try:
                 desktop_web_driver.get(endpoint)

--- a/tests/mobile_native.sh
+++ b/tests/mobile_native.sh
@@ -5,4 +5,5 @@ export LATEST_ANDROID_GITHUB_RELEASE=$(python3 latest_github_release.py android)
 echo "React Native Github Release v$LATEST_REACT_NATIVE_GITHUB_RELEASE"
 echo "Android Github Release v$LATEST_ANDROID_GITHUB_RELEASE"
 
-while true; do clear && pytest -s -n 4 mobile_native; done
+# Note: BATCH_SIZE currently not used in mobile tests
+while true; do clear && SE_TAG=tda BATCH_SIZE=random_20 pytest -s -n 4 mobile_native; done

--- a/tests/util/test_n.sh
+++ b/tests/util/test_n.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# TDA performance test used to determine optimal number of threads (-n ?)
+# to use when running on a given number of VMs in Saucelabs or other Selenium Grid
+
+date
+for i in {1..12}; do
+  echo "-n $i"
+  SE_TAG=util_test_n_$i BATCH_SIZE=10 py.test -s -n $i desktop_web
+done
+date
+


### PR DESCRIPTION
The idea is to un-hardcode certain things to make it easier to develop and test new changes (e.g. freeze batch size at certain value and compare number of events generated BEFORE and AFTER the change) as well to make things generally more explicit. Tagging TDA's own errors with SE_TAG allows to easily check if anything failed in a development branch by separating test run failures from continuously-running 'tda' failures.

- `BATCH_SIZE` (default 1 instead of old randrange(20))
- use `SE_TAG` for TDA's own errors (default to system user, instead of old "tda")
  - now need to explicitly supply `SE_TAG` and `BATCH_SIZE` in desktop_web.sh and mobile_native.sh
- default `SE_TAG` to system user
- include links to /issues in the report: GENERATED errors and OWN errors (filtered by `se` tag and session start/end time)
- un-hardcode BACKENDS for simple predictable output when regression-testing
- don't pretend that we're not hardcoding DSN
- util/test_n.sh to determine optimal number of threads to run on N VMs

## Testing
BACKENDS=flask python3 -m pytest -n 7 desktop_web; SE_TAG=tda-test-1 BATCH_SIZE=random_5 python3 -m pytest -n 7 desktop_web/test_add_to_cart.py; SE_TAG=tda-test-2 BATCH_SIZE=3 python3 -m pytest -n 7 desktop_web/test_add_to_cart.py
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [32] / gw1 [32] / gw2 [32] / gw3 [32] / gw4 [32] / gw5 [32] / gw6 [32]
................................                                                                                                                    [100%]
============================================================= 32 passed in 321.10s (0:05:21) ==============================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Akosty+%21project%3Ajob-monitor-application-monitoring&start=2023-02-17T05%3A31%3A15&end=2023-02-17T05%3A36%3A37
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Akosty&start=2023-02-17T05%3A31%3A15&end=2023-02-17T05%3A36%3A37
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4] / gw4 [4] / gw5 [4] / gw6 [4]
....                                                                                                                                                [100%]
============================================================== 4 passed in 188.56s (0:03:08) ==============================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Atda-test-1+%21project%3Ajob-monitor-application-monitoring&start=2023-02-17T05%3A36%3A36&end=2023-02-17T05%3A39%3A46
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Atda-test-1&start=2023-02-17T05%3A36%3A36&end=2023-02-17T05%3A39%3A46
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4] / gw4 [4] / gw5 [4] / gw6 [4]
....                                                                                                                                                [100%]
============================================================== 4 passed in 189.42s (0:03:09) ==============================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Atda-test-2+%21project%3Ajob-monitor-application-monitoring&start=2023-02-17T05%3A39%3A45&end=2023-02-17T05%3A42%3A56
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Atda-test-2&start=2023-02-17T05%3A39%3A45&end=2023-02-17T05%3A42%3A56