### PR TITLE
[aspnetcore] - enabled tracing

### DIFF
--- a/aspnetcore/Startup.cs
+++ b/aspnetcore/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using aspnetcore.Models;
+using Sentry.AspNetCore;
 
 namespace aspnetcore
 {
@@ -54,6 +55,8 @@ namespace aspnetcore
             app.UseCors(allowSpecificOrigins);
 
             app.UseRouting();
+
+            app.UseSentryTracing();
 
             app.UseAuthorization();
 

--- a/aspnetcore/appsettings.json.template
+++ b/aspnetcore/appsettings.json.template
@@ -12,5 +12,6 @@
   },
   "Sentry": {
     "Dsn": "<SENTRY_DSN>",
+    "TracesSampleRate": 1.0,
   },
 }


### PR DESCRIPTION
TESTING Staging
[Automatic .NET performance instrumentation](https://testorg-az.sentry.io/performance/?project=4504461107396608)
[Distributed tracing on issues](https://testorg-az.sentry.io/performance/trace/904455a894c540a78e52bd9762be4081/?pageEnd=2023-02-18T01%3A10%3A52.252&pageStart=2023-02-17T01%3A10%3A52.252)
[Full trace of /Products](https://testorg-az.sentry.io/performance/trace/a64e919b94324dfc8466db2ac834a3cb/?pageEnd=2023-02-18T01%3A10%3A46.812&pageStart=2023-02-17T01%3A10%3A46.736)

NOTE: 
[N+1 is not implemented](https://testorg-az.sentry.io/performance/staging-application-monitoring-aspnetcore:a7e192fc9d0e49eb8e6d20d05f7497b8/?project=4504461107396608&query=http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=7d&transaction=GET+Products&unselectedSeries=p100%28%29) - as the db query is not slowed yet

Next steps:
- Show full stack trace on .NET Core Issues
- Slow down db query
