### PR TITLE
[tda + react] move ?crash= randomization out into TDA, seed random if SE_TAG != 'tda'

### DIFF
--- a/react/src/utils/errors.js
+++ b/react/src/utils/errors.js
@@ -26,9 +26,8 @@ const randomErrors = [
   unhandledError
 ]
 
-const throwRandomError = () => {
-  const randomNum = parseInt(Math.random()*randomErrors.length)
-  randomErrors[randomNum]()
+const throwErrorNumber = (i) => {
+  randomErrors[i % randomErrors.length]()
 }
 
 // if n is 0.2 then this will return false 20% of the time
@@ -42,8 +41,9 @@ const crasher = () => {
     const crash = queryParams.get("crash")
     if (crash) {
       console.log("> crash", crash)
+      const errnum = queryParams.get("errnum") || parseInt(Math.random()*randomErrors.length)
       if (crash === "true" || probability(parseFloat(crash))) {
-        throwRandomError();
+        throwErrorNumber(errnum);
       }
     }
   } else {

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -7,6 +7,9 @@ from urllib.parse import urlencode
 from collections import OrderedDict
 from datetime import datetime
 
+# n - float in [0,1]
+def probability(p):
+    return random.random() <= p 
 
 # This test is for the homepage '/' transaction
 def test_homepage(desktop_web_driver):
@@ -39,13 +42,17 @@ def test_homepage(desktop_web_driver):
             # Randomize the Failure Rate between 1% and 20% or 40%, depending what week it is. Returns values like 0.02, 0.14, 0.37
             n = random.uniform(0.01, upper_bound)
 
+            crash = probability(n) and 1.0 or 0.0
+            errnum = random.randint(0, 999) # decides which error type is thrown
+
             # This query string is parsed by utils/errors.js wherever the 'crasher' function is used
             # and causes the page to periodically crash, for Release Health
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
                 'se': pytest.SE_TAG,
                 'backend': pytest.random_backend(),
-                'crash': "%s" % (n)
+                'crash': "%s" % (crash),
+                'errnum': "%d" % (errnum)
             }
             url = endpoint + '?' + urlencode(query_string)
 


### PR DESCRIPTION
This change ensures that every time the same set of tests is run you get exactly same results in terms of generated errors and transactions. This allows to test for regressions when making changes to TDA.

## Testing

BATCH_SIZE=random_100 python3 -m pytest -n 7 desktop_web/test_homepage.py
========================================================== test session starts ===========================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4] / gw4 [4] / gw5 [4] / gw6 [4]
....                                                                                                                               [100%]
===================================================== 4 passed in 338.83s (0:05:38) ======================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Akosty+%21project%3Ajob-monitor-application-monitoring&start=2023-02-18T05%3A07%3A02&end=2023-02-18T05%3A12%3A42
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Akosty&start=2023-02-18T05%3A07%3A02&end=2023-02-18T05%3A12%3A42
BATCH_SIZE=random_100 python3 -m pytest -n 7 desktop_web/test_homepage.py
========================================================== test session starts ===========================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4] / gw4 [4] / gw5 [4] / gw6 [4]
....                                                                                                                               [100%]
===================================================== 4 passed in 344.69s (0:05:44) ======================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Akosty+%21project%3Ajob-monitor-application-monitoring&start=2023-02-18T05%3A12%3A51&end=2023-02-18T05%3A18%3A37
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Akosty&start=2023-02-18T05%3A12%3A51&end=2023-02-18T05%3A18%3A37

BATCH_SIZE=random_20 python3 -m pytest -n 7 desktop_web
========================================================== test session starts ===========================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [32] / gw1 [32] / gw2 [32] / gw3 [32] / gw4 [32] / gw5 [32] / gw6 [32]
................................                                                                                                   [100%]
===================================================== 32 passed in 355.27s (0:05:55) =====================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Akosty+%21project%3Ajob-monitor-application-monitoring&start=2023-02-18T05%3A27%3A35&end=2023-02-18T05%3A33%3A32
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Akosty&start=2023-02-18T05%3A27%3A35&end=2023-02-18T05%3A33%3A32
BATCH_SIZE=random_20 python3 -m pytest -n 7 desktop_web
========================================================== test session starts ===========================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [32] / gw1 [32] / gw2 [32] / gw3 [32] / gw4 [32] / gw5 [32] / gw6 [32]
................................                                                                                                   [100%]
===================================================== 32 passed in 409.06s (0:06:49) =====================================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Akosty+%21project%3Ajob-monitor-application-monitoring&start=2023-02-18T05%3A34%3A06&end=2023-02-18T05%3A40%3A56
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Akosty&start=2023-02-18T05%3A34%3A06&end=2023-02-18T05%3A40%3A56