### PR TITLE
[deploy] Use same 'v1' version for ALL projects to avoid hitting GAE version max

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -214,7 +214,7 @@ for proj in $projects; do # bash only
     else
       # all other projects
       sed -e 's/<SERVICE>/'$app_engine_service'/g' app.yaml.template > .app.yaml
-      gcloud app deploy --quiet .app.yaml
+      gcloud app deploy --version v1 --quiet .app.yaml
     fi
   fi
 done


### PR DESCRIPTION
prevents this from happening:
https://github.com/sentry-demos/application-monitoring/actions/runs/4228239243/jobs/7343489401

also potentially prevents accidentally getting billed for GAE Flexible storage

### Testing
```
./deploy.sh --env=staging react
./deploy.sh --env=staging react
```
https://console.cloud.google.com/appengine/versions?project=sales-engineering-sf&serviceId=staging-application-monitoring-react