### PR TITLE
[tda] set SE tag URL parameter automatically for all webdriver GET requests

### DIFF
--- a/tests/desktop_web/test_about_employees.py
+++ b/tests/desktop_web/test_about_employees.py
@@ -14,7 +14,6 @@ def test_about_employees(desktop_web_driver, endpoints):
         # You can filter by se:tda in Sentry's UI as this will get set as a tag
         url = ""
         query_string = {
-            'se': pytest.SE_TAG,
             'backend': pytest.random_backend()
         }
         url = endpoint_about + '?' + urlencode(query_string)

--- a/tests/desktop_web/test_about_employees.py
+++ b/tests/desktop_web/test_about_employees.py
@@ -1,18 +1,13 @@
 import time
-import yaml
 import random
 import sentry_sdk
 import pytest
 from urllib.parse import urlencode
 
-def test_about_employees(desktop_web_driver):
+def test_about_employees(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_about_employees")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['react_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints['react_endpoints']:
         endpoint_about = endpoint + "/about"
         sentry_sdk.set_tag("endpoint", endpoint_about)
 

--- a/tests/desktop_web/test_about_employees_vue.py
+++ b/tests/desktop_web/test_about_employees_vue.py
@@ -2,7 +2,6 @@ import time
 import pytest
 import random
 import sentry_sdk
-from urllib.parse import urlencode
 from collections import OrderedDict
 
 def test_about_employees_vue(desktop_web_driver, endpoints):

--- a/tests/desktop_web/test_about_employees_vue.py
+++ b/tests/desktop_web/test_about_employees_vue.py
@@ -1,19 +1,14 @@
 import time
-import yaml
 import pytest
 import random
 import sentry_sdk
 from urllib.parse import urlencode
 from collections import OrderedDict
 
-def test_about_employees_vue(desktop_web_driver):
+def test_about_employees_vue(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_about_employees_vue")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['vue_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints["vue_endpoints"]:
 
         endpoint = endpoint + "/about"
 

--- a/tests/desktop_web/test_add_to_cart.py
+++ b/tests/desktop_web/test_add_to_cart.py
@@ -19,7 +19,6 @@ def test_add_to_cart(desktop_web_driver, endpoints):
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                'se': pytest.SE_TAG,
                 # 'ruby' /products /checkout endpoints not available yet
                 'backend': pytest.random_backend(exclude='ruby')
             }

--- a/tests/desktop_web/test_add_to_cart.py
+++ b/tests/desktop_web/test_add_to_cart.py
@@ -1,19 +1,14 @@
 import time
-import yaml
 import random
 import sentry_sdk
 import pytest
 from urllib.parse import urlencode
 from selenium.webdriver.common.by import By
 
-def test_add_to_cart(desktop_web_driver):
+def test_add_to_cart(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_add_to_cart")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['react_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints['react_endpoints']:
         endpoint_products = endpoint + "/products"
         sentry_sdk.set_tag("endpoint", endpoint_products)
 

--- a/tests/desktop_web/test_add_to_cart_join.py
+++ b/tests/desktop_web/test_add_to_cart_join.py
@@ -1,18 +1,13 @@
 import time
-import yaml
 import random
 import sentry_sdk
 import pytest
 from urllib.parse import urlencode
 
-def test_add_to_cart_join(desktop_web_driver):
+def test_add_to_cart_join(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_add_to_cart_join")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['react_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints['react_endpoints']:
         endpoint_products_join = endpoint + "/products-join"
         sentry_sdk.set_tag("endpoint", endpoint_products_join)
 

--- a/tests/desktop_web/test_add_to_cart_join.py
+++ b/tests/desktop_web/test_add_to_cart_join.py
@@ -16,7 +16,6 @@ def test_add_to_cart_join(desktop_web_driver, endpoints):
             url = ""
             # TODO make a query_string builder function for sharing this across tests
             query_string = { 
-                'se': pytest.SE_TAG,
                 # 'ruby' /products /checkout endpoints not available yet
                 'backend': pytest.random_backend(exclude=['ruby', 'laravel'])
             }

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -38,7 +38,6 @@ def test_homepage(desktop_web_driver, endpoints):
             # and causes the page to periodically crash, for Release Health
             # TODO make a query_string builder function for sharing this across tests
             query_string = {
-                'se': pytest.SE_TAG,
                 'backend': pytest.random_backend(),
                 'crash': "%s" % (n)
             }

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -1,5 +1,4 @@
 import time
-import yaml
 import random
 import sentry_sdk
 import pytest
@@ -9,12 +8,8 @@ from datetime import datetime
 
 
 # This test is for the homepage '/' transaction
-def test_homepage(desktop_web_driver):
+def test_homepage(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_homepage")
-
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['react_endpoints']
 
     # Find what week it is, as this is used as the patch version in YY.MM.W like 22.6.2
     d=datetime.today()
@@ -32,7 +27,7 @@ def test_homepage(desktop_web_driver):
         upper_bound = .4
 
 
-    for endpoint in endpoints:
+    for endpoint in endpoints['react_endpoints']:
         sentry_sdk.set_tag("endpoint", endpoint)
 
         for i in range(pytest.batch_size()):

--- a/tests/desktop_web/test_homepage_vue.py
+++ b/tests/desktop_web/test_homepage_vue.py
@@ -1,5 +1,4 @@
 import time
-import yaml
 import pytest
 import random
 import sentry_sdk
@@ -8,14 +7,10 @@ from collections import OrderedDict
 from selenium.webdriver.common.by import By
 
 # Note: Not sure why won't pytest find this and run it when I name it 'vue_test_homepage'
-def test_homepage_vue(desktop_web_driver):
+def test_homepage_vue(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_homepage_vue")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['vue_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints['vue_endpoints']:
 
         # TODO homepage endpoint loads Products but in future will need to append /products to the endpoint
         sentry_sdk.set_tag("endpoint", endpoint)

--- a/tests/desktop_web/test_homepage_vue.py
+++ b/tests/desktop_web/test_homepage_vue.py
@@ -2,7 +2,6 @@ import time
 import pytest
 import random
 import sentry_sdk
-from urllib.parse import urlencode
 from collections import OrderedDict
 from selenium.webdriver.common.by import By
 

--- a/tests/desktop_web/test_organization.py
+++ b/tests/desktop_web/test_organization.py
@@ -1,18 +1,13 @@
 import time
-import yaml
 import random
 import pytest
 import sentry_sdk
 from urllib.parse import urlencode
 
-def test_organization(desktop_web_driver):
+def test_organization(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_organization")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['react_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints['react_endpoints']:
         endpoint_organization = endpoint + "/organization"
         sentry_sdk.set_tag("endpoint", endpoint_organization)
 

--- a/tests/desktop_web/test_organization.py
+++ b/tests/desktop_web/test_organization.py
@@ -2,7 +2,6 @@ import time
 import random
 import pytest
 import sentry_sdk
-from urllib.parse import urlencode
 
 def test_organization(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_organization")
@@ -11,12 +10,7 @@ def test_organization(desktop_web_driver, endpoints):
         endpoint_organization = endpoint + "/organization"
         sentry_sdk.set_tag("endpoint", endpoint_organization)
 
-        # You can filter by se:tda in Sentry's UI as this will get set as a tag
-        url = ""
-        query_string = { 
-            'se': pytest.SE_TAG,
-        }
-        url = endpoint_organization + '?' + urlencode(query_string)
+        url = endpoint_organization
 
         for i in range(pytest.batch_size()):
         

--- a/tests/desktop_web/test_subscribe_vue.py
+++ b/tests/desktop_web/test_subscribe_vue.py
@@ -1,5 +1,4 @@
 import time
-import yaml
 import pytest
 import random
 import sentry_sdk
@@ -7,14 +6,10 @@ from urllib.parse import urlencode
 from collections import OrderedDict
 from selenium.webdriver.common.by import By
 
-def test_subscribe_vue(desktop_web_driver):
+def test_subscribe_vue(desktop_web_driver, endpoints):
     sentry_sdk.set_tag("pytestName", "test_subscribe_vue")
 
-    with open('endpoints.yaml', 'r') as stream:
-        data_loaded = yaml.safe_load(stream)
-        endpoints = data_loaded['vue_endpoints']
-
-    for endpoint in endpoints:
+    for endpoint in endpoints['vue_endpoints']:
         
         endpoint = endpoint + "/subscribe"
 

--- a/tests/desktop_web/test_subscribe_vue.py
+++ b/tests/desktop_web/test_subscribe_vue.py
@@ -2,7 +2,6 @@ import time
 import pytest
 import random
 import sentry_sdk
-from urllib.parse import urlencode
 from collections import OrderedDict
 from selenium.webdriver.common.by import By
 


### PR DESCRIPTION
- less code
- no need to remember to add the tag
- fixes some tests that were missing SE tag (e.g. `test_homepage_vue.py` - not sure if vue supports the tag but it doen't hurt)

### Testing
tested as part of bigger set of changes