### PR TITLE
[tda] Automatically set pytestPlatform and pytestName tags

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,12 +214,23 @@ def selenium_endpoint(data_center):
     else:
         return SAUCELABS_PROTOCOL + "{}:{}@ondemand.us-west-1.saucelabs.com/wd/hub".format(username, access_key)
 
+@pytest.fixture
+def set_tags(request):
+    # request.fixturenames: Names of all active fixtures in this request.
+    # e.g value: ['android_emu_driver', 'request', 'set_tags', 'selenium_endpoint', 'data_center']
+    # NOTE: we depend on driver fixtures following *_driver naming convention here
+    driver_name = list(filter(lambda x: x.endswith('_driver'), request.fixturenames))[0]
+    # request.node: Underlying collection node (depends on current request scope).
+    # e.g name: test_myfunction[desktop_web_driver0]
+    test_name = request.node.name.split('[')[0]
+    platform = driver_name.replace('_emu_driver', '').replace('_sim_driver', '').replace('_driver','')
+    sentry_sdk.set_tag("pytestPlatform", platform)
+    sentry_sdk.set_tag("pytestName", test_name)
+
 @pytest.fixture(params=desktop_browsers)
-def desktop_web_driver(request, selenium_endpoint):
+def desktop_web_driver(request, set_tags, selenium_endpoint):
 
     try:
-        sentry_sdk.set_tag("pytestPlatform", "desktop_web")
-
         test_name = request.node.name
         build_tag = environ.get('BUILD_TAG', "Application-Monitoring-TDA")
 
@@ -272,11 +283,9 @@ def desktop_web_driver(request, selenium_endpoint):
         sentry_sdk.capture_exception(err)
 
 @pytest.fixture
-def android_react_native_emu_driver(request, selenium_endpoint):
+def android_react_native_emu_driver(request, set_tags, selenium_endpoint):
 
     try:
-        sentry_sdk.set_tag("pytestPlatform", "android_react_native")
-
         release_version = ReleaseVersion.latest_react_native_github_release()
 
         options = UiAutomator2Options().load_capabilities({
@@ -309,11 +318,9 @@ def android_react_native_emu_driver(request, selenium_endpoint):
         sentry_sdk.capture_exception(err)
 
 @pytest.fixture
-def android_emu_driver(request, selenium_endpoint):
+def android_emu_driver(request, set_tags, selenium_endpoint):
 
     try:
-        sentry_sdk.set_tag("pytestPlatform", "android")
-
         release_version = ReleaseVersion.latest_android_github_release()
 
         options = UiAutomator2Options().load_capabilities({
@@ -346,11 +353,9 @@ def android_emu_driver(request, selenium_endpoint):
         sentry_sdk.capture_exception(err)
 
 @pytest.fixture
-def ios_react_native_sim_driver(request, selenium_endpoint):
+def ios_react_native_sim_driver(request, set_tags, selenium_endpoint):
 
     try:
-        sentry_sdk.set_tag("pytestPlatform", "ios_react_native")
-
         release_version = ReleaseVersion.latest_react_native_github_release()
 
         options = XCUITestOptions().load_capabilities({
@@ -383,11 +388,9 @@ def ios_react_native_sim_driver(request, selenium_endpoint):
         sentry_sdk.capture_exception(err)
 
 @pytest.fixture
-def ios_sim_driver(request, selenium_endpoint):
+def ios_sim_driver(request, set_tags, selenium_endpoint):
 
     try:
-        sentry_sdk.set_tag("pytestPlatform", "ios")
-
         release_version = ReleaseVersion.latest_ios_github_release()
 
         options = XCUITestOptions().load_capabilities({

--- a/tests/desktop_web/test_about_employees.py
+++ b/tests/desktop_web/test_about_employees.py
@@ -4,7 +4,6 @@ import pytest
 from urllib.parse import urlencode
 
 def test_about_employees(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_about_employees")
 
     for endpoint in endpoints['react_endpoints']:
         endpoint_about = endpoint + "/about"

--- a/tests/desktop_web/test_about_employees_vue.py
+++ b/tests/desktop_web/test_about_employees_vue.py
@@ -2,7 +2,6 @@ import time
 import sentry_sdk
 
 def test_about_employees_vue(desktop_web_driver, endpoints, random, batch_size, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_about_employees_vue")
 
     for endpoint in endpoints["vue_endpoints"]:
 

--- a/tests/desktop_web/test_checkout.py
+++ b/tests/desktop_web/test_checkout.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 from selenium.webdriver.common.by import By
 
 def test_checkout(desktop_web_driver, endpoints, batch_size, backend, random, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_checkout")
 
     for endpoint in endpoints['react_endpoints']:
         sentry_sdk.set_tag("endpoint", "/")

--- a/tests/desktop_web/test_homepage.py
+++ b/tests/desktop_web/test_homepage.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 # This test is for the homepage '/' transaction
 def test_homepage(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_homepage")
 
     # n - float in [0,1]
     def probability(p):

--- a/tests/desktop_web/test_homepage_vue.py
+++ b/tests/desktop_web/test_homepage_vue.py
@@ -5,7 +5,6 @@ from selenium.webdriver.common.by import By
 
 # Note: Not sure why won't pytest find this and run it when I name it 'vue_test_homepage'
 def test_homepage_vue(desktop_web_driver, endpoints, random, batch_size, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_homepage_vue")
 
     for endpoint in endpoints['vue_endpoints']:
 

--- a/tests/desktop_web/test_organization.py
+++ b/tests/desktop_web/test_organization.py
@@ -3,7 +3,6 @@ import pytest
 import sentry_sdk
 
 def test_organization(desktop_web_driver, endpoints, random, batch_size, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_organization")
 
     for endpoint in endpoints['react_endpoints']:
         endpoint_organization = endpoint + "/organization"

--- a/tests/desktop_web/test_products_join.py
+++ b/tests/desktop_web/test_products_join.py
@@ -3,7 +3,6 @@ import sentry_sdk
 from urllib.parse import urlencode
 
 def test_products_join(desktop_web_driver, endpoints, random, batch_size, backend, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_products_join")
 
     for endpoint in endpoints['react_endpoints']:
         endpoint_products_join = endpoint + "/products-join"

--- a/tests/desktop_web/test_subscribe_vue.py
+++ b/tests/desktop_web/test_subscribe_vue.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from selenium.webdriver.common.by import By
 
 def test_subscribe_vue(desktop_web_driver, endpoints, random, batch_size, sleep_length):
-    sentry_sdk.set_tag("pytestName", "test_subscribe_vue")
 
     for endpoint in endpoints['vue_endpoints']:
         

--- a/tests/mobile_native/android/test_anr_android.py
+++ b/tests/mobile_native/android/test_anr_android.py
@@ -6,7 +6,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 # Application Not Responding button
 @pytest.mark.skip(reason="not working")
 def test_anr_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_anr_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android/test_checkout_android.py
+++ b/tests/mobile_native/android/test_checkout_android.py
@@ -4,7 +4,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 # 'Regular' as in non-react-native
 def test_checkout_regular_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_checkout_regular_android")
 
     try:
         # Add items to cart

--- a/tests/mobile_native/android/test_handlederror_android.py
+++ b/tests/mobile_native/android/test_handlederror_android.py
@@ -3,7 +3,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 # Clicks the Handled Error button that says ArrayIndexOutOfBoundsException
 def test_handlederror_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_handlederror_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android/test_httperror_android.py
+++ b/tests/mobile_native/android/test_httperror_android.py
@@ -4,7 +4,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 # Automatically capture HTTP Errors with range (400 - 599) status codes
 def test_httperror_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_httperror_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android/test_nativecrash_android.py
+++ b/tests/mobile_native/android/test_nativecrash_android.py
@@ -6,7 +6,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 # NDK/C++ Native Crash SIGSEGV button
 @pytest.mark.skip(reason="not working")
 def test_nativecrash_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_nativecrash_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android/test_nativemessage_android.py
+++ b/tests/mobile_native/android/test_nativemessage_android.py
@@ -3,7 +3,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 # NDK/C++ Native Message button
 def test_nativemessage_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_nativemessage_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android/test_unhandlederror2_android.py
+++ b/tests/mobile_native/android/test_unhandlederror2_android.py
@@ -3,7 +3,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 # Clicks the Unhandled Error button - NegativeArraySizeException - the button says RTE and Strip PII
 def test_unhandlederror2_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_unhandlederror2_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android/test_unhandlederror_android.py
+++ b/tests/mobile_native/android/test_unhandlederror_android.py
@@ -3,7 +3,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 # Clicks the Unhandled Error button that says ArithmeticException
 def test_unhandlederror_android(android_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_unhandlederror_android")
 
     try:
         # navigate to list app

--- a/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_captureexception_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_captureexception_react_native_android(android_react_native_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_captureexception_react_native_android")
 
     try:
         # click into list app screen

--- a/tests/mobile_native/android_react_native/test_capturemessage_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_capturemessage_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_capturemessage_react_native_android(android_react_native_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_capturemessage_react_native_android")
 
     try:
         # click into list app screen

--- a/tests/mobile_native/android_react_native/test_checkout_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_checkout_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_checkout_react_native_android(android_react_native_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_checkout_react_native_android")
 
     try:
         add_to_cart_btn = android_react_native_emu_driver.find_element(AppiumBy.XPATH, '/hierarchy/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[1]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup/android.widget.ScrollView/android.view.ViewGroup/android.view.ViewGroup[1]/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup/android.widget.TextView')

--- a/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_homescreen_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_homescreen_react_native_android(android_react_native_emu_driver, random):
-    sentry_sdk.set_tag("pytestName", "test_homescreen_react_native_android")
 
     try:
         # click into list app screen

--- a/tests/mobile_native/android_react_native/test_nativecrash_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_nativecrash_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_nativecrash_react_native_android(android_react_native_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_nativecrash_react_native_android")
 
     try:
         # click into list app screen

--- a/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_uncaughtthrownerror_react_native_android(android_react_native_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_uncaughtthrownerror_react_native_android")
 
     try:
         # click into list app screen

--- a/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
+++ b/tests/mobile_native/android_react_native/test_unhandledpromiserejection_react_native_android.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_unhandledpromiserejection_react_native_android(android_react_native_emu_driver):
-    sentry_sdk.set_tag("pytestName", "test_unhandledpromiserejection_react_native_android")
 
     try:
         # click into list app screen

--- a/tests/mobile_native/ios/test_checkout_ios.py
+++ b/tests/mobile_native/ios/test_checkout_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_checkout_ios(ios_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_checkout_ios")
 
     try:
         first_item = ios_sim_driver.find_element(AppiumBy.XPATH, '//XCUIElementTypeApplication[@name="EmpowerPlant"]/XCUIElementTypeWindow/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeTable[1]/XCUIElementTypeCell[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther')

--- a/tests/mobile_native/ios_react_native/test_captureexception_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_captureexception_react_native_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_captureexception_react_native_ios(ios_react_native_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_captureexception_react_native_ios")
 
     try:
         # click on list app

--- a/tests/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_capturemessage_react_native_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_capturemessage_react_native_ios(ios_react_native_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_capturemessage_react_native_ios")
 
     try:
         # click on list app

--- a/tests/mobile_native/ios_react_native/test_checkout_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_checkout_react_native_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_checkout_react_native_ios(ios_react_native_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_checkout_react_native_ios")
 
     try:
         cart_btn = ios_react_native_sim_driver.find_element(AppiumBy.XPATH, '(//XCUIElementTypeOther[@name="Add to Cart"])[1]')

--- a/tests/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_nativecrash_react_native_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_nativecrash_react_native_ios(ios_react_native_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_nativecrash_react_native_ios")
 
     try:
         # click on list app

--- a/tests/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_uncaughtthrownerror_react_native_ios(ios_react_native_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_uncaughtthrownerror_react_native_ios")
     
     try:
         # click on list app

--- a/tests/mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
+++ b/tests/mobile_native/ios_react_native/test_unhandledpromiserejection_react_native_ios.py
@@ -2,7 +2,6 @@ import sentry_sdk
 from appium.webdriver.common.appiumby import AppiumBy
 
 def test_unhandledpromiserejection_react_native_ios(ios_react_native_sim_driver):
-    sentry_sdk.set_tag("pytestName", "test_unhandledpromiserejection_react_native_ios")
 
     try:
         # click on list app


### PR DESCRIPTION
### Testing
Tags still there after refactor:

pytestName
[test_nativecrash_react_native_ios](https://testorg-az.sentry.io/issues/?end=2023-03-16T02%3A46%3A53&project=5390094&query=se%3Akosty%20pytestName%3Atest_nativecrash_react_native_ios&referrer=event-tags&start=2023-03-16T02%3A31%3A59)
pytestPlatform
[ios_react_native](https://testorg-az.sentry.io/issues/?end=2023-03-16T02%3A46%3A53&project=5390094&query=se%3Akosty%20pytestPlatform%3Aios_react_native&referrer=event-tags&start=2023-03-16T02%3A31%3A59)

python3 -m pytest -n 3
========================================================== test session starts ===========================================================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/kosty/home/am/tests
plugins: forked-1.4.0, xdist-3.1.0
gw0 [54] / gw1 [54] / gw2 [54]
................................s..s..................                                                                             [100%]
============================================================ warnings summary ============================================================
mobile_native/android_react_native/test_nativecrash_react_native_android.py::test_nativecrash_react_native_android
mobile_native/android_react_native/test_uncaughtthrownerror_react_native_android.py::test_uncaughtthrownerror_react_native_android
mobile_native/ios_react_native/test_nativecrash_react_native_ios.py::test_nativecrash_react_native_ios
mobile_native/ios_react_native/test_uncaughtthrownerror_react_native_ios.py::test_uncaughtthrownerror_react_native_ios
  /Users/kosty/home/am/tests/env/lib/python3.8/site-packages/appium/webdriver/extensions/applications.py:112: DeprecationWarning: The "launchApp" API is deprecated and will be removed in future versions. See https://github.com/appium/appium/issues/15807
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================= 52 passed, 2 skipped, 4 warnings in 893.07s (0:14:53) ==========================================

GENERATED errors: https://testorg-az.sentry.io/issues/?query=se%3Akosty+%21project%3Ajob-monitor-application-monitoring&start=2023-03-16T02%3A31%3A59&end=2023-03-16T02%3A46%3A53
OWN errors:       https://testorg-az.sentry.io/issues/?project=5390094&query=se%3Akosty&start=2023-03-16T02%3A31%3A59&end=2023-03-16T02%3A46%3A53