### PR TITLE
Revert "Add python profiling slow method (#183)"

### DIFF
--- a/flask/main.py
+++ b/flask/main.py
@@ -8,7 +8,7 @@ from flask import Flask, json, request, make_response
 from flask_cors import CORS
 from dotenv import load_dotenv
 from db import get_products, get_products_join, get_inventory
-from utils import parseHeaders, get_iterator
+from utils import parseHeaders
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -20,12 +20,6 @@ DSN = os.environ["FLASK_APP_DSN"]
 ENVIRONMENT = os.environ["FLASK_ENV"]
 RUBY_BACKEND = os.environ["RUBY_BACKEND"]
 RUBY_CUSTOM_HEADERS = ['se', 'customerType', 'email']
-
-pests = ["aphids", "thrips", "spider mites", "lead miners", "scale", "whiteflies", "earwigs", "cutworms", "mealybugs", "fungus gnats"]
-RUN_SLOW_PROFILE = True
-if "RUN_SLOW_PROFILE" in os.environ:
-    if os.environ["RUN_SLOW_PROFILE"].lower() == "false":
-        RUN_SLOW_PROFILE = False
 
 print("> DSN", DSN)
 print("> RELEASE", RELEASE)
@@ -104,29 +98,14 @@ def products():
     try:
         with sentry_sdk.start_span(op="/products.get_products", description="function"):
             rows = get_products()
-
-            if RUN_SLOW_PROFILE:
-                productsJSON = json.loads(rows)
-                descriptions = [product["description"] for product in productsJSON]
-                with sentry_sdk.start_span(op="/get_iterator", description="function"):
-                    loop = get_iterator(len(descriptions) * 6)
-                    for i in range(loop):
-                        for i, description in enumerate(descriptions):
-                            for pest in pests:
-                                if pest in description:
-                                    try:
-                                        del productsJSON[i:i+1]
-                                    except:
-                                        productsJSON = json.loads(rows)
     except Exception as err:
         sentry_sdk.capture_exception(err)
         raise(err)
 
     try:
-        with sentry_sdk.start_span(op="/api_request", description="function"):
-            headers = parseHeaders(RUBY_CUSTOM_HEADERS, request.headers)
-            r = requests.get(RUBY_BACKEND + "/api", headers=headers)
-            r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
+        headers = parseHeaders(RUBY_CUSTOM_HEADERS, request.headers)
+        r = requests.get(RUBY_BACKEND + "/api", headers=headers)
+        r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)
         

--- a/flask/utils.py
+++ b/flask/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import numpy
 from pytz import timezone
 import time
 from random import choices
@@ -26,14 +27,3 @@ def parseHeaders(keys, headers):
         value = headers.get(key) if headers.get(key) != "undefined" else None
         parsedHeaders[key] = value
     return parsedHeaders
-
-def get_iterator(n):
-    #fibonacci
-    if n < 0:
-        print("Incorrect input")
-    elif n == 0:
-        return 0
-    elif n == 1 or n == 2:
-        return 1
-    else:
-        return get_iterator(n-1) + get_iterator(n-2)


### PR DESCRIPTION
This reverts commit 4bfd719d4ad7cbe58d870fc6f988f27b5edc89ed.

## Testing

- [Staging frontend still working](https://staging-application-monitoring-react-dot-sales-engineering-sf.appspot.com/products)
- [Staging flask backend still working](https://staging-application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products)
- [Profile captured for flask backend (Without slow method)](https://testorg-az.sentry.io/profiling/profile/staging-application-monitoring-python/d5a11de7bb454c0ea58aa3865290fcec/flamechart/?colorCoding=by+system+vs+application+frame&fov=0%2C0%2C2188467968%2C18&query=&sorting=call+order&tid=68190858118912&view=top+down)