### PR TITLE
Add python slow method

### DIFF
--- a/flask/main.py
+++ b/flask/main.py
@@ -8,7 +8,7 @@ from flask import Flask, json, request, make_response
 from flask_cors import CORS
 from dotenv import load_dotenv
 from db import get_products, get_products_join, get_inventory
-from utils import parseHeaders
+from utils import parseHeaders, get_iterator
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -20,6 +20,11 @@ DSN = os.environ["FLASK_APP_DSN"]
 ENVIRONMENT = os.environ["FLASK_ENV"]
 RUBY_BACKEND = os.environ["RUBY_BACKEND"]
 RUBY_CUSTOM_HEADERS = ['se', 'customerType', 'email']
+
+pests = ["aphids", "thrips", "spider mites", "lead miners", "scale", "whiteflies", "earwigs", "cutworms", "mealybugs", "fungus gnats"]
+RUN_SLOW_PROFILE = True
+if "RUN_SLOW_PROFILE" in os.environ:
+    RUN_SLOW_PROFILE = os.environ["RUN_SLOW_PROFILE"].lower() == "true"
 
 print("> DSN", DSN)
 print("> RELEASE", RELEASE)
@@ -98,14 +103,34 @@ def products():
     try:
         with sentry_sdk.start_span(op="/products.get_products", description="function"):
             rows = get_products()
+            
+            if RUN_SLOW_PROFILE:
+                start_time = time.time()
+                productsJSON = json.loads(rows)
+                descriptions = [product["description"] for product in productsJSON]
+                with sentry_sdk.start_span(op="/get_iterator", description="function"):
+                    loop = get_iterator(len(descriptions) * 6)
+                    for i in range(loop):
+                        time_delta = time.time() - start_time
+                        if time_delta > 4:
+                            break
+
+                        for i, description in enumerate(descriptions):
+                            for pest in pests:
+                                if pest in description:
+                                    try:
+                                        del productsJSON[i:i+1]
+                                    except:
+                                        productsJSON = json.loads(rows)
     except Exception as err:
         sentry_sdk.capture_exception(err)
         raise(err)
 
     try:
-        headers = parseHeaders(RUBY_CUSTOM_HEADERS, request.headers)
-        r = requests.get(RUBY_BACKEND + "/api", headers=headers)
-        r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
+        with sentry_sdk.start_span(op="/api_request", description="function"):
+            headers = parseHeaders(RUBY_CUSTOM_HEADERS, request.headers)
+            r = requests.get(RUBY_BACKEND + "/api", headers=headers)
+            r.raise_for_status() # returns an HTTPError object if an error has occurred during the process
     except Exception as err:
         sentry_sdk.capture_exception(err)
         

--- a/flask/utils.py
+++ b/flask/utils.py
@@ -27,3 +27,14 @@ def parseHeaders(keys, headers):
         value = headers.get(key) if headers.get(key) != "undefined" else None
         parsedHeaders[key] = value
     return parsedHeaders
+
+def get_iterator(n):
+    #fibonacci
+    if n < 0:
+        print("Incorrect input")
+    elif n == 0:
+        return 0
+    elif n == 1 or n == 2:
+        return 1
+    else:
+        return get_iterator(n-1) + get_iterator(n-2)


### PR DESCRIPTION
This should be an improved attempt to enable what (#183) attempted to do

The problem with #183 was that the slow method ran for way too long, disrupting the demo-flow for SEs. This iteration of the change implements a timeout of 4 seconds to make sure it does not go over it (In most cases it should not, but this is a safeguard)

- [staging event example](https://testorg-az.sentry.io/performance/staging-application-monitoring-python:4a0b3e06bc18445b98cd945171436adc/)

- url : https://staging-application-monitoring-react-dot-sales-engineering-sf.appspot.com/products